### PR TITLE
feat: have transformProps use current entity data

### DIFF
--- a/src/hooks/useEntity.tsx
+++ b/src/hooks/useEntity.tsx
@@ -1,5 +1,30 @@
 import { useQuery } from "@tanstack/react-query";
 import { fetchEntity } from "../utils/api";
+import { Role } from "../templates/edit";
+
+/**
+ * If the role is "individual" and the entity's config data is populated, 
+ * returns the entityId's config data. Else returns the site entity's config data. 
+ */
+export const getPuckData = (
+  siteEntityId: string,
+  field: string,
+  entityId?: string,
+  role?: string
+): string => {
+  const { entity, status } = useEntity(role === Role.INDIVIDUAL && entityId ? entityId : siteEntityId);
+  const { entity: siteEntity, status: siteEntityStatus } = useEntity(siteEntityId);
+  if (status === "success" && entity.response?.[field]) {
+    return entity?.response?.[field] ?? "";
+  } else if (
+    role === Role.INDIVIDUAL &&
+    siteEntityStatus === "success" &&
+    siteEntity.response?.[field]
+  ) {
+    return siteEntity?.response?.[field] ?? "";
+  }
+  return "";
+};
 
 const useEntity = (entityId: string) => {
   const { data: entity, status: status } = useQuery({

--- a/src/puck/editor.tsx
+++ b/src/puck/editor.tsx
@@ -15,7 +15,7 @@ export interface EditorProps {
   entities: EntityDefinition[];
   selectedTemplate: TemplateDefinition;
   templates: TemplateDefinition[];
-  siteEntityId: string;
+  entityId: string;
   puckConfig: Config;
   puckData: string;
 }
@@ -26,7 +26,7 @@ export const Editor = ({
   entities,
   selectedTemplate,
   templates,
-  siteEntityId,
+  entityId,
   puckConfig,
   puckData,
 }: EditorProps) => {
@@ -61,7 +61,7 @@ export const Editor = ({
   const save = async (data: Data) => {
     const templateData = JSON.stringify(data);
     mutation.mutate({
-      entityId: siteEntityId,
+      entityId: entityId,
       body: { [selectedTemplate.dataField]: templateData },
     });
   };

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -16,10 +16,15 @@ import { Config } from "@measured/puck";
 import { puckConfigs } from "../puck/puck.config";
 import { TemplateDefinition } from "../components/puck-overrides/TemplatePicker";
 import { EntityDefinition } from "../components/puck-overrides/EntityPicker";
-import useEntity from "../hooks/useEntity";
+import { getPuckData } from "../hooks/useEntity";
 import { LoadingScreen } from "../components/puck-overrides/LoadingScreen";
 
+export const Role = {
+  GLOBAL: "global",
+  INDIVIDUAL: "individual"
+}
 const siteEntityId = "site";
+const role = Role.GLOBAL;
 
 export const config: TemplateConfig = {
   name: "edit",
@@ -126,9 +131,7 @@ const Edit: Template<TemplateRenderProps> = () => {
     getData();
   }, []);
 
-  // fetch the puck data from our site entity
-  const { entity: siteEntity } = useEntity(siteEntityId);
-  const puckData = template ? siteEntity?.response?.[template.dataField] : "";
+  const puckData = getPuckData(siteEntityId, template?.dataField ?? "", entity?.externalId, role)
 
   // get the document
   const { entityDocument } = useEntityDocumentQuery({
@@ -176,7 +179,7 @@ const Edit: Template<TemplateRenderProps> = () => {
             entities={entities}
             selectedTemplate={template}
             templates={templates}
-            siteEntityId={siteEntityId}
+            entityId={role === Role.INDIVIDUAL ? entity?.externalId : siteEntityId}
             puckConfig={puckConfig}
             puckData={puckData}
           />


### PR DESCRIPTION
If the current entity, doesn't have the required field or the field is empty, it'll use the site entity's data instead