### PR TITLE
feat: add undo/redo buttons to header

### DIFF
--- a/src/components/puck-overrides/Header.tsx
+++ b/src/components/puck-overrides/Header.tsx
@@ -3,6 +3,10 @@ import { EntityDefinition, EntityPicker } from "./EntityPicker";
 import "./puck.css";
 import { TemplateDefinition, TemplatePicker } from "./TemplatePicker";
 import { useDocument } from "../../hooks/useDocument";
+import { usePuck } from "@measured/puck";
+import { RotateCcw, RotateCw } from "lucide-react"
+import * as buttons from "../ui/Button"
+
 
 const handleClick = (slug: string) => {
   window.open(`/${slug}`, "_blank");
@@ -10,9 +14,19 @@ const handleClick = (slug: string) => {
 
 export const customHeaderActions = (children: any) => {
   const entityDocument = useDocument();
+  const {
+    history: { back, forward, historyStore },
+  } = usePuck();
+  const { hasFuture = false, hasPast = false } = historyStore || {};
   return (
     <>
       {children}
+      <buttons.Button variant="ghost" size="icon" disabled={!hasPast} onClick={back}>
+        <RotateCcw className="h-4 w-4" />
+      </buttons.Button>
+      <buttons.Button variant="ghost" size="icon" disabled={!hasFuture} onClick={forward}>
+        <RotateCw className="h-4 w-4" />
+      </buttons.Button>
       <Button onClick={() => handleClick(entityDocument.slug)}>
         Live Preview
       </Button>


### PR DESCRIPTION
Verified that if changes are made that undo is enabled and successfully reverts the change, and if undo is clicked then redo is enabled and successfully updates the page.

![UndoButton](https://github.com/YextSolutions/pages-visual-editor-starter/assets/88292188/14e64192-357a-4564-b6a1-7637d6d32b26)

