### PR TITLE
feat(dev): use layoutId to pull and save data

### DIFF
--- a/src/components/puck-overrides/Header.tsx
+++ b/src/components/puck-overrides/Header.tsx
@@ -17,13 +17,13 @@ const handleClearLocalChanges = () => {
   window.location.reload();
 };
 
-export const customHeaderActions = (children: any, templateId: string, entityId: string, role: string) => {
+export const customHeaderActions = (children: any, templateId: string, layoutId: string, entityId: string, role: string) => {
   const entityDocument = useDocument();
   const {
     history: { back, forward, historyStore },
   } = usePuck();
   const { hasFuture = false, hasPast = false } = historyStore || {};
-  const hasLocalStorage = !!window.localStorage.getItem(getLocalStorageKey(role, templateId, entityId));
+  const hasLocalStorage = !!window.localStorage.getItem(getLocalStorageKey(role, templateId, layoutId, entityId));
   return (
     <>
       {children}

--- a/src/utils/localStorageHelper.ts
+++ b/src/utils/localStorageHelper.ts
@@ -1,8 +1,16 @@
-import {Role} from "../templates/edit";
+import { Role } from "../templates/edit";
 
-export function getLocalStorageKey(role: string, templateId: string, entityId: string) {
-  if (role === Role.INDIVIDUAL) {
-    return role + "_" + templateId + "_" + entityId;
+const ROLE= "ROLE_",
+    TEMPLATE= "TEMPLATE_",
+    LAYOUT= "LAYOUT_",
+    ENTITY= "ENTITY_";
+
+export function getLocalStorageKey(role: string, templateId: string, layoutId: string, entityId: string) {
+  if (!role || !templateId || (!entityId && !layoutId)) {
+    throw new Error("Unable to generate local storage key, missing query parameters");
   }
-  return role + "_" + templateId;
+  if (role === Role.INDIVIDUAL) {
+    return ROLE + role + TEMPLATE + templateId + ENTITY + entityId;
+  }
+  return ROLE + role + TEMPLATE + templateId + LAYOUT + layoutId;
 }


### PR DESCRIPTION
LayoutID is used to pull and save data when using the 'global' role.

Verified that local cache, pull, and save works for all templates, layouts, and roles.