### PR TITLE
YextSitesStorm: VE - Update Publish Button

### DIFF
--- a/src/components/puck-overrides/Header.tsx
+++ b/src/components/puck-overrides/Header.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@measured/puck";
+import {Button, Data} from "@measured/puck";
 import "./puck.css";
 import { useDocument } from "../../hooks/useDocument";
 import { usePuck } from "@measured/puck";
@@ -22,7 +22,7 @@ const handleClick = (slug: string) => {
   window.open(`/${slug}`, "_blank");
 };
 
-export const customHeaderActions = (children: any, templateId: string, layoutId: string, entityId: string, role: string, handleClearLocalChanges : Function, handleHistoryChange: (history: any) => void) => {
+export const customHeader = (templateId: string, layoutId: string, entityId: string, role: string, handleClearLocalChanges: Function, handleHistoryChange: (history: any) => void, data: Data | undefined, handleSaveData: Function) => {
   const entityDocument = useDocument();
   const {
     history: { back, forward, historyStore },
@@ -30,61 +30,53 @@ export const customHeaderActions = (children: any, templateId: string, layoutId:
   const { hasFuture = false, hasPast = false } = historyStore || {};
   const hasLocalStorage = !!window.localStorage.getItem(getLocalStorageKey(role, templateId, layoutId, entityId));
   useEffect(() => {
-      handleHistoryChange(historyStore);
+    handleHistoryChange(historyStore);
   }, [historyStore?.index]);
 
   return (
-    <>
-    {children}
-    <buttons.Button variant="ghost" size="icon" disabled={!hasPast} onClick={back}>
-      <RotateCcw className="sm-icon" />
-    </buttons.Button>
-    <buttons.Button variant="ghost" size="icon" disabled={!hasFuture} onClick={forward}>
-      <RotateCw className="sm-icon" />
-    </buttons.Button>
-    <AlertDialog>
-      <AlertDialogTrigger disabled={!hasLocalStorage} asChild>
-        <Button>Clear Local Changes</Button>
-      </AlertDialogTrigger>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Clear Local Changes</AlertDialogTitle>
-          <AlertDialogDescription>
-            This action will remove your local changes. It cannot be undone.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <Button onClick={() => handleClearLocalChanges()}>
-            Confirm
+      <header className="puck-header">
+        <div className="header-left">
+          <ToggleUIButtons/>
+        </div>
+        <div className="header-center">
+        </div>
+        <div className="actions">
+          <buttons.Button variant="ghost" size="icon" disabled={!hasPast} onClick={back}>
+            <RotateCcw className="sm-icon"/>
+          </buttons.Button>
+          <buttons.Button variant="ghost" size="icon" disabled={!hasFuture} onClick={forward}>
+            <RotateCw className="sm-icon"/>
+          </buttons.Button>
+          <AlertDialog>
+            <AlertDialogTrigger disabled={!hasLocalStorage} asChild>
+              <Button>Clear Local Changes</Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Clear Local Changes</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This action will remove your local changes. It cannot be undone.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <Button onClick={() => handleClearLocalChanges()}>
+                  Confirm
+                </Button>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+          <Button onClick={() => handleClick(entityDocument.slug)}>
+            Live Preview
           </Button>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-    <Button onClick={() => handleClick(entityDocument.slug)}>
-      Live Preview
-    </Button>
-  </>
-
-  );
-};
-
-export interface customHeaderProps {
-  actions: any;
-}
-
-export const customHeader = ({
-  actions
-}: customHeaderProps) => {
-  return (
-    <header className="puck-header">
-      <div className="header-left">
-        <ToggleUIButtons/>
-      </div>
-      <div className="header-center">
-      </div>
-      <div className="actions">{actions}</div>
-    </header>
+          <Button disabled={!hasLocalStorage} onClick={async () => {
+            await handleSaveData(data);
+            handleClearLocalChanges();
+          }}>
+            Publish
+          </Button>
+        </div>
+      </header>
   );
 };
 

--- a/src/puck/editor.tsx
+++ b/src/puck/editor.tsx
@@ -71,6 +71,7 @@ export const Editor = ({
   const mutation = useUpdateEntityMutation();
   const [canEdit, setCanEdit] = useState<boolean>(false);
   const historyIndex = useRef<number>(-1);
+  const [data, setData] = useState<Data>();
 
   const handleHistoryChange = useCallback((history: any) => {
     if (history.index !== -1 && historyIndex.current !== history.index) {
@@ -169,35 +170,36 @@ export const Editor = ({
       setCanEdit(true);
       return;
     }
-
+    setData(data);
     window.localStorage.setItem(
       getLocalStorageKey(role, selectedTemplate.id, layoutId, entityId),
       JSON.stringify(data),
     );
   };
 
+  const handleSave = async (data : Data) => {
+    await save(data, role);
+  };
+
   return (
-    <Puck
-      config={puckConfig}
-      data={JSON.parse(puckData)}
-      onPublish={(data: Data) => save(data, role)}
-      onChange={change}
-      overrides={{
-        headerActions: ({ children }) =>
-          customHeaderActions(
-            children,
-            selectedTemplate.id,
-            layoutId,
-            entityId,
-            role,
-            handleClearLocalChanges,
-            handleHistoryChange,
-          ),
-        header: ({ actions }) =>
-          customHeader({
-            actions: actions,
-          }),
-      }}
-    />
+      <Puck
+          config={puckConfig}
+          data={JSON.parse(puckData)}
+          onChange={change}
+          overrides={{
+            header: () =>
+                customHeader(
+                    selectedTemplate.id,
+                    layoutId,
+                    entityId,
+                    role,
+                    handleClearLocalChanges,
+                    handleHistoryChange,
+                    data,
+                    handleSave
+                ),
+          }}
+      />
   );
 };
+


### PR DESCRIPTION
Overrides the default puck publish button to allow for disabling it, while keeping the same save functionality as before and adds clearing the local changes from Ethan's PR.

Video demo:
https://drive.google.com/file/d/164QFpwYSS22wDRNu0dynXb6MPbqBI1D9/view?usp=sharing

