### PR TITLE
fix: remove template from messagePayload

### DIFF
--- a/src/puck/editor.tsx
+++ b/src/puck/editor.tsx
@@ -9,13 +9,12 @@ import { useEffect, useState, useRef, useCallback } from "react";
 import { getLocalStorageKey } from "../utils/localStorageHelper";
 import {
   MessagePayload,
-  Template,
   VisualConfiguration,
 } from "../types/messagePayload";
 import { type History } from "../templates/edit";
 
 export interface EditorProps {
-  selectedTemplate: Template;
+  selectedTemplateId: string;
   puckConfig: Config;
   puckData: any; // json object
   role: string;
@@ -40,7 +39,7 @@ export const siteEntityVisualConfigField = "c_visualLayouts",
 
 // Render Puck editor
 export const Editor = ({
-  selectedTemplate,
+  selectedTemplateId,
   puckConfig,
   puckData,
   role,
@@ -75,7 +74,7 @@ export const Editor = ({
         window.localStorage.setItem(
           getLocalStorageKey(
             role,
-            selectedTemplate.id,
+            selectedTemplateId,
             messagePayload.layoutId,
             messagePayload.entity?.id
           ),
@@ -99,7 +98,7 @@ export const Editor = ({
   const handleClearLocalChanges = () => {
     clearHistory(
       messagePayload.role,
-      selectedTemplate.id,
+      selectedTemplateId,
       messagePayload.layoutId,
       messagePayload.entity?.id
     );
@@ -134,13 +133,13 @@ export const Editor = ({
         entity[baseEntityVisualConfigField] ?? [];
       const existingTemplate = visualConfigs.find(
         (visualConfig: VisualConfiguration) =>
-          visualConfig.template === selectedTemplate.id
+          visualConfig.template === selectedTemplateId
       );
       if (existingTemplate) {
         existingTemplate.data = templateData;
       } else {
         visualConfigs.push({
-          template: selectedTemplate.id,
+          template: selectedTemplateId,
           data: templateData,
         });
       }
@@ -162,7 +161,7 @@ export const Editor = ({
       // for global role, we save to the layout entity
       const visualConfig: VisualConfiguration = {
         data: templateData,
-        template: selectedTemplate.id,
+        template: selectedTemplateId,
       };
       window.localStorage.removeItem(
         getLocalStorageKey(

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -284,7 +284,7 @@ const Edit: () => JSX.Element = () => {
         {!isLoading && !!puckData && !!messagePayload ? (
           <>
             <Editor
-              selectedTemplate={messagePayload.template}
+              selectedTemplateId={messagePayload.templateId}
               puckConfig={puckConfig}
               puckData={puckData}
               role={messagePayload.role}

--- a/src/types/messagePayload.ts
+++ b/src/types/messagePayload.ts
@@ -35,13 +35,6 @@ export type Scope = {
   locales: string[];
 };
 
-export type Template = {
-  id: string;
-  name: string;
-  scope: Scope;
-  entityTypes: string[];
-};
-
 export type SaveState = {
   history: any; // json object
   hash: string;
@@ -54,7 +47,6 @@ export type MessagePayload = {
   layoutId?: number;
   layouts: Layout[];
   role: string;
-  template: Template;
   templateId: string;
   saveState?: SaveState;
 };
@@ -110,17 +102,6 @@ export const convertRawMessageToObject = (
     layoutId: layoutForExternalLayoutId?.id,
     layouts: layouts,
     role: messageParams.role,
-    template: {
-      id: messageParams.template.id,
-      name: messageParams.template.name,
-      scope: {
-        entityIds: messageParams.template.entities,
-        entityTypeIds: messageParams.template.entityTypeIds,
-        savedSearchIds: messageParams.template.savedSearches,
-        locales: messageParams.template.locales,
-      },
-      entityTypes: messageParams.template.entityTypes,
-    },
     templateId: messageParams.templateId,
     saveState: messageParams.saveState
       ? {


### PR DESCRIPTION
Storm no longer sends the template down because we only use templateId, this refactors VE starter to reflect that change.