### PR TITLE
fix(dev): fix JSON escape

### DIFF
--- a/src/types/messagePayload.ts
+++ b/src/types/messagePayload.ts
@@ -63,7 +63,7 @@ export const convertRawMessageToObject = (
       name: layout.name,
       templateId: layout.templateId,
       visualConfiguration: jsonFromEscapedJsonString(
-        layout.visualConfiguration
+        layout?.visualConfiguration
       ),
       isDefault: layout.isDefault,
       entityIds: layout.entityIds,
@@ -118,5 +118,12 @@ export const convertRawMessageToObject = (
 
 // TODO: Remove this when the frontend has been fixed to not string escape
 const jsonFromEscapedJsonString = (escapedJsonString: string) => {
-  return JSON.parse(escapedJsonString.replace(/\\"/g, '"'));
+  if (!escapedJsonString) {
+    return {};
+  }
+  try {
+    return JSON.parse(escapedJsonString);
+  } catch (ignored) {
+    return JSON.parse(escapedJsonString.replace(/\\"/g, '"'));
+  }
 };


### PR DESCRIPTION
json escape is failing due to an odd
message getting picked up

Handles the empty/null string case and
also attempts to parse the string directly
before escaping.

On my prod branch, this fixes the issue and
the editor page loads properly.