### PR TITLE
fix: add null case for layout.c_visualConfiguration

### DIFF
--- a/src/puck/editor.tsx
+++ b/src/puck/editor.tsx
@@ -117,7 +117,7 @@ export const Editor = ({
     <EntityFieldProvider>
       <Puck
         config={puckConfig}
-        data={puckData as Partial<Data>}
+        data={puckData as Partial<Data> ?? {"root":{},"content":[],"zones":{}}}
         initialHistory={
           index === -1 ? undefined : { histories: histories, index: index }
         }


### PR DESCRIPTION
Handle a null VisualEditorConfig in layout entities, will adjust the c_visualConfiguration in #104 such that data isn't required for a new layout (so if left empty, it defaults to {"root":{},"content":[],"zones":{}}

Change-Id: Ibb6e4dbb43dd772304d46bebd1490aeb3a1d8a9b