### PR TITLE
fix: adjust enable tooltips button in Header

### DIFF
--- a/src/puck/components/Header.tsx
+++ b/src/puck/components/Header.tsx
@@ -5,7 +5,7 @@ import {
   PanelRight,
   RotateCcw,
   RotateCw,
-  RectangleEllipsis,
+  MessageSquareText,
 } from "lucide-react";
 import {
   AlertDialog,
@@ -188,7 +188,7 @@ const ToggleEntityFields = () => {
       <Tooltip>
         <TooltipTrigger>
           <Button variant="ghost" size="icon" onClick={toggleTooltips} className={tooltipsVisible ? "border-2 border-[#5A58F2] rounded-full" : ""}>
-            <RectangleEllipsis className="sm-icon" />
+            <MessageSquareText className="sm-icon" />
           </Button>
         </TooltipTrigger>
         <TooltipContent>


### PR DESCRIPTION
Only shows tooltip for that button on hover. Icon is adjusted as requested by design. 


https://github.com/user-attachments/assets/a5de52bc-c080-45bd-b88a-0c49539401e1

