### PR TITLE
feat(dev): send puck history to parent in dev mode

### DIFF
--- a/src/puck/editor.tsx
+++ b/src/puck/editor.tsx
@@ -71,7 +71,7 @@ export const Editor = ({
           if (templateMetadata.isDevMode) {
             sendDevSaveStateData({
               payload: {
-                devSaveStateData: JSON.stringify(histories[index].data.data),
+                devSaveStateData: JSON.stringify(histories[index].data?.data),
               },
             })
           } else {

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -233,7 +233,7 @@ const Edit: () => JSX.Element = () => {
       );
       const localHistoryArray = localHistory ? JSON.parse(localHistory) : [];
       const historyToSend = JSON.stringify(localHistoryArray.length > 0 ? 
-        localHistoryArray[localHistoryArray.length-1].data.data : {});
+        localHistoryArray[localHistoryArray.length-1].data?.data : {});
         sendDevSaveStateData({ payload: { devSaveStateData: historyToSend } });
     }
   }, [templateMetadata]);


### PR DESCRIPTION
Ran locally alongside the corresponding platform code and verified that the puck history was correctly sent to the platform, which allowed for the live preview to be shown successfully while in dev mode.