### PR TITLE
fix: resolve console error "<button> cannot appear as a descendant of <button>"

### DIFF
--- a/src/puck/components/Header.tsx
+++ b/src/puck/components/Header.tsx
@@ -194,7 +194,7 @@ const ToggleEntityFields = () => {
   return (
     <TooltipProvider>
       <Tooltip>
-        <TooltipTrigger>
+        <TooltipTrigger asChild>
           <Button
             variant="ghost"
             size="icon"


### PR DESCRIPTION
Ran the VE through dev mode an the Entity Fields toggle still works as before