### PR TITLE
feat: redirect to 404.html if no parent

### DIFF
--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -63,7 +63,7 @@ const Edit: () => JSX.Element = () => {
     if (window.parent.name) {
       setHasParent(true);
     }
-  }, [setHasParent]);
+  }, []);
 
   const redirectTo404 = () => {
     if (typeof window !== "undefined") {


### PR DESCRIPTION
Verified that if there is no parent, the user is redirect to a 404 page and that no content loads prior to the redirect.