### PR TITLE
feat(dev): reapply push page sets to parent in dev mode

### DIFF
--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -57,6 +57,17 @@ const Edit: () => JSX.Element = () => {
   const [entityDocument, setEntityDocument] = useState<any>(); // json data
   const [saveState, setSaveState] = useState<SaveState>();
   const [saveStateFetched, setSaveStateFetched] = useState<boolean>(false); // needed because saveState can be empty
+  const [devPageSets, setDevPageSets] = useState<any>(undefined);
+
+  useEffect(() => {
+    if (templateMetadata?.isDevMode) {
+      try {
+        setDevPageSets(pageSets); // pageSets is a global variable set by pagesJS
+      } catch (ignored) {
+        console.warn("pageSets are not defined");
+      }
+    }
+  }, [templateMetadata?.isDevMode]);
 
   /**
    * Clears the user's localStorage and resets the current Puck history
@@ -250,6 +261,18 @@ const Edit: () => JSX.Element = () => {
     setTemplateMetadata(payload);
     send({ status: "success", payload: { message: "payload received" } });
   });
+
+  const { sendToParent: pushPageSets } = useSendMessageToParent(
+      "pushPageSets", TARGET_ORIGINS
+  )
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && templateMetadata?.isDevMode && devPageSets) {
+      pushPageSets({
+        payload: devPageSets,
+      });
+    }
+  }, [templateMetadata?.isDevMode, devPageSets]);
 
   const { sendToParent: saveSaveState } = useSendMessageToParent(
     "saveSaveState",


### PR DESCRIPTION
This restores the original "push page sets to parent in dev mode" with an added change to check that the pageSets exist so that it works without the PagesJS change.

This reverts commit b34d7f149eaa317819faf44f401ff2963dd03c43.