### PR TITLE
feat: redirect to 404.html if origin is not in storm

### DIFF
--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -61,8 +61,8 @@ const Edit: () => JSX.Element = () => {
   const [hasParent, setHasParent] = useState<boolean>(false);
 
   useEffect(() => {
-    console.log("parent: " + window.parent);
-    if (window.parent.name) {
+    console.log(window.parent);
+    if (window.parent) {
       setHasParent(true);
     }
   }, []);

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -62,6 +62,7 @@ const Edit: () => JSX.Element = () => {
 
   useEffect(() => {
     if (typeof window !== "undefined") {
+      console.log(window.parent.location);
       const ancestors = window.parent.location.ancestorOrigins;
       if (ancestors.length === 0) {
         setHasParent(false);

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -41,11 +41,7 @@ export type PuckInitialHistory = {
   index: number;
 };
 
-const ParentStatus = {
-  LOADED: "loaded",
-  NULL: "null",
-  PENDING: "pending",
-}
+type ParentStatus = "loaded" | "null" | "pending";
 
 // Render the editor
 const Edit: () => JSX.Element = () => {
@@ -64,24 +60,20 @@ const Edit: () => JSX.Element = () => {
   const [saveState, setSaveState] = useState<SaveState>();
   const [saveStateFetched, setSaveStateFetched] = useState<boolean>(false); // needed because saveState can be empty
   const [devPageSets, setDevPageSets] = useState<any>(undefined);
-  const [parentStatus, setParentStatus] = useState<string>(ParentStatus.PENDING);
+  const [parentStatus, setParentStatus] = useState<ParentStatus>("pending");
 
   useEffect(() => {
     if (typeof window !== "undefined") {
       const ancestors = window.location.ancestorOrigins;
       if (ancestors.length === 0) {
-        setParentStatus(ParentStatus.NULL);
+        setParentStatus("null");
       } else if (!ancestors[0].includes("pagescdn") && !ancestors[0].includes("yext.com")) {
-        setParentStatus(ParentStatus.NULL);
+        setParentStatus("null");
       } else {
-        setParentStatus(ParentStatus.LOADED);
+        setParentStatus("loaded");
       }
     }
   }, []);
-
-  const redirectTo404 = () => {
-    window.location.href = "/404.html";
-  }
 
   useEffect(() => {
     if (templateMetadata?.isDevMode) {
@@ -375,11 +367,11 @@ const Edit: () => JSX.Element = () => {
         </DocumentProvider>
       ) : 
       (
-        parentStatus === ParentStatus.LOADED ?
+        parentStatus === "loaded" ?
          (
           <LoadingScreen progress={progress} />
         ) : 
-        parentStatus === ParentStatus.NULL && redirectTo404()
+        parentStatus === "null" && window.location.assign("/404.html")
       )}
       <Toaster closeButton richColors />
     </>

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -367,13 +367,23 @@ const Edit: () => JSX.Element = () => {
             sendDevSaveStateData={sendDevSaveStateData}
           />
         </DocumentProvider>
-      ) : (
-        hasParent && typeof window !== "undefined" ?
-         (
-          <LoadingScreen progress={progress} />
-        ) : 
-        !hasParent && redirectTo404()
-      )}
+      ) : 
+      (
+        // hasParent && typeof window !== "undefined" ?
+        //  (
+        //   <LoadingScreen progress={progress} />
+        // ) : 
+        // !hasParent && redirectTo404()
+        useEffect(() => {
+          if (typeof window !== "undefined" && !hasParent) {
+            window.location.href = "/404.html";
+          }
+          if (typeof window !== "undefined" && hasParent) {
+            <LoadingScreen progress={progress} />
+          }
+        }, [hasParent])
+      )
+      }
       <Toaster closeButton richColors />
     </>
   );

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -75,7 +75,7 @@ const Edit: () => JSX.Element = () => {
 
   const redirectTo404 = () => {
     if (typeof window !== "undefined") {
-      window.location.href = "/404.html";
+      //window.location.href = "/404.html";
     }
   }
 

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -68,7 +68,10 @@ const Edit: () => JSX.Element = () => {
       const ancestors = window.location.ancestorOrigins;
       if (ancestors.length === 0) {
         setHasParent(false);
+        console.log("here1?");
       } else if (!ancestors[0].includes("pagescdn") || !ancestors[0].includes("yext.com")) {
+        console.log(ancestors[0]);
+        console.log("here?");
         setHasParent(false);
       }
     }

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -368,7 +368,7 @@ const Edit: () => JSX.Element = () => {
          (
           <LoadingScreen progress={progress} />
         ) : 
-        redirectTo404()
+        !hasParent && redirectTo404()
       )}
       <Toaster closeButton richColors />
     </>

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -61,7 +61,7 @@ const Edit: () => JSX.Element = () => {
   const [hasParent, setHasParent] = useState<boolean>(false);
 
   useEffect(() => {
-    console.log(window.parent);
+    console.log("parent: " + window.parent);
     if (window.parent.name) {
       setHasParent(true);
     }

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -41,7 +41,7 @@ export type PuckInitialHistory = {
   index: number;
 };
 
-type ParentStatus = "loaded" | "null" | "pending";
+type ParentStatus = "loaded" | "pending";
 
 // Render the editor
 const Edit: () => JSX.Element = () => {
@@ -66,9 +66,9 @@ const Edit: () => JSX.Element = () => {
     if (typeof window !== "undefined") {
       const ancestors = window.location.ancestorOrigins;
       if (ancestors.length === 0) {
-        setParentStatus("null");
+        window.location.assign("/404.html");
       } else if (!ancestors[0].includes("pagescdn") && !ancestors[0].includes("yext.com")) {
-        setParentStatus("null");
+        window.location.assign("/404.html");
       } else {
         setParentStatus("loaded");
       }
@@ -367,11 +367,7 @@ const Edit: () => JSX.Element = () => {
         </DocumentProvider>
       ) : 
       (
-        parentStatus === "loaded" ?
-         (
-          <LoadingScreen progress={progress} />
-        ) : 
-        parentStatus === "null" && window.location.assign("/404.html")
+        parentStatus === "loaded" && <LoadingScreen progress={progress} />
       )}
       <Toaster closeButton richColors />
     </>

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -58,15 +58,13 @@ const Edit: () => JSX.Element = () => {
   const [saveState, setSaveState] = useState<SaveState>();
   const [saveStateFetched, setSaveStateFetched] = useState<boolean>(false); // needed because saveState can be empty
   const [devPageSets, setDevPageSets] = useState<any>(undefined);
-  const [hasParent, setHasParent] = useState<boolean>(true);
+  const [hasParent, setHasParent] = useState<boolean>(false);
 
   useEffect(() => {
     if (typeof window !== "undefined") {
       const ancestors = window.location.ancestorOrigins;
-      if (ancestors.length === 0) {
-        setHasParent(false);
-      } else if (!ancestors[0].includes("pagescdn") && !ancestors[0].includes("yext.com")) {
-        setHasParent(false);
+      if  (ancestors[0].includes("pagescdn") || ancestors[0].includes("yext.com")) {
+        setHasParent(true);
       }
     }
   }, []);

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -62,6 +62,7 @@ const Edit: () => JSX.Element = () => {
 
   useEffect(() => {
     if (typeof window !== "undefined") {
+      console.log(window.parent);
       console.log(window.parent.location);
       const ancestors = window.parent.location.ancestorOrigins;
       if (ancestors.length === 0) {

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -58,12 +58,12 @@ const Edit: () => JSX.Element = () => {
   const [saveState, setSaveState] = useState<SaveState>();
   const [saveStateFetched, setSaveStateFetched] = useState<boolean>(false); // needed because saveState can be empty
   const [devPageSets, setDevPageSets] = useState<any>(undefined);
-  const [hasParent, setHasParent] = useState<boolean>(false);
+  const [hasParent, setHasParent] = useState<boolean>(true);
 
   useEffect(() => {
     console.log(window.parent);
-    if (window.parent) {
-      setHasParent(true);
+    if (!window.parent.name) {
+      setHasParent(false);
     }
   }, []);
 

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -374,14 +374,17 @@ const Edit: () => JSX.Element = () => {
         //   <LoadingScreen progress={progress} />
         // ) : 
         // !hasParent && redirectTo404()
-        useEffect(() => {
-          if (typeof window !== "undefined" && !hasParent) {
-            window.location.href = "/404.html";
-          }
-          if (typeof window !== "undefined" && hasParent) {
-            <LoadingScreen progress={progress} />
-          }
-        }, [hasParent])
+        <>
+        {
+          useEffect(() => {
+            if (typeof window !== "undefined" && !hasParent) {
+              window.location.href = "/404.html";
+            }
+          }, [hasParent])
+        }
+        {typeof window !== "undefined" && hasParent && <LoadingScreen progress={progress} />}
+        </>
+      
       )
       }
       <Toaster closeButton richColors />

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -62,18 +62,10 @@ const Edit: () => JSX.Element = () => {
 
   useEffect(() => {
     if (typeof window !== "undefined") {
-      console.log(window);
-      console.log(window.location);
-      console.log(window.location.ancestorOrigins);
       const ancestors = window.location.ancestorOrigins;
       if (ancestors.length === 0) {
         setHasParent(false);
-        console.log("here1?");
-      } else if (!ancestors[0].includes("pagescdn") || !ancestors[0].includes("yext.com")) {
-        console.log(!ancestors[0].includes("pagescdn"));
-        console.log(!ancestors[0].includes("yext.com"));
-        console.log(ancestors[0][0]);
-        console.log("here?");
+      } else if (!ancestors[0].includes("pagescdn") && !ancestors[0].includes("yext.com")) {
         setHasParent(false);
       }
     }
@@ -81,7 +73,7 @@ const Edit: () => JSX.Element = () => {
 
   const redirectTo404 = () => {
     if (typeof window !== "undefined") {
-      //window.location.href = "/404.html";
+      window.location.href = "/404.html";
     }
   }
 

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -369,24 +369,12 @@ const Edit: () => JSX.Element = () => {
         </DocumentProvider>
       ) : 
       (
-        // hasParent && typeof window !== "undefined" ?
-        //  (
-        //   <LoadingScreen progress={progress} />
-        // ) : 
-        // !hasParent && redirectTo404()
-        <>
-        {
-          useEffect(() => {
-            if (typeof window !== "undefined" && !hasParent) {
-              window.location.href = "/404.html";
-            }
-          }, [hasParent])
-        }
-        {typeof window !== "undefined" && hasParent && <LoadingScreen progress={progress} />}
-        </>
-      
-      )
-      }
+        hasParent && typeof window !== "undefined" ?
+         (
+          <LoadingScreen progress={progress} />
+        ) : 
+        !hasParent && redirectTo404()
+      )}
       <Toaster closeButton richColors />
     </>
   );

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -64,7 +64,7 @@ const Edit: () => JSX.Element = () => {
   useEffect(() => {
     console.log(window.parent);
     if (typeof window !== "undefined") {
-      if (!window.parent) {
+      if (window.parent) {
         setHasParent(false);
       }
     }

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -64,7 +64,7 @@ const Edit: () => JSX.Element = () => {
   useEffect(() => {
     console.log(window.parent);
     if (typeof window !== "undefined") {
-      if (!window.parent.name) {
+      if (!window.parent) {
         setHasParent(false);
       }
     }

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -70,7 +70,9 @@ const Edit: () => JSX.Element = () => {
         setHasParent(false);
         console.log("here1?");
       } else if (!ancestors[0].includes("pagescdn") || !ancestors[0].includes("yext.com")) {
-        console.log(ancestors[0]);
+        console.log(!ancestors[0].includes("pagescdn"));
+        console.log(!ancestors[0].includes("yext.com"));
+        console.log(ancestors[0][0]);
         console.log("here?");
         setHasParent(false);
       }

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -68,7 +68,7 @@ const Edit: () => JSX.Element = () => {
   }, []);
 
   const redirectTo404 = () => {
-    if (typeof window !== "undefined") {
+    if (typeof window !== "undefined" && !hasParent) {
       window.location.href = "/404.html";
     }
   }
@@ -364,7 +364,7 @@ const Edit: () => JSX.Element = () => {
           />
         </DocumentProvider>
       ) : (
-        hasParent ?
+        hasParent && typeof window !== "undefined" ?
          (
           <LoadingScreen progress={progress} />
         ) : 

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -63,7 +63,7 @@ const Edit: () => JSX.Element = () => {
   useEffect(() => {
     if (typeof window !== "undefined") {
       console.log(window.parent);
-      console.log(window.parent.location);
+      console.log(window.parent[2].location.ancestorOrigins);
       const ancestors = window.parent.location.ancestorOrigins;
       if (ancestors.length === 0) {
         setHasParent(false);
@@ -75,7 +75,7 @@ const Edit: () => JSX.Element = () => {
 
   const redirectTo404 = () => {
     if (typeof window !== "undefined") {
-      window.location.href = "/404.html";
+      //window.location.href = "/404.html";
     }
   }
 

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -63,7 +63,8 @@ const Edit: () => JSX.Element = () => {
   useEffect(() => {
     if (typeof window !== "undefined") {
       console.log(window);
-      console.log(window.parent);
+      console.log(window.location);
+      console.log(window.location.ancestorOrigins);
       const ancestors = window.location.ancestorOrigins;
       if (ancestors.length === 0) {
         setHasParent(false);

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -60,15 +60,18 @@ const Edit: () => JSX.Element = () => {
   const [devPageSets, setDevPageSets] = useState<any>(undefined);
   const [hasParent, setHasParent] = useState<boolean>(true);
 
+  console.log(hasParent)
   useEffect(() => {
     console.log(window.parent);
-    if (!window.parent.name) {
-      setHasParent(false);
+    if (typeof window !== "undefined") {
+      if (!window.parent.name) {
+        setHasParent(false);
+      }
     }
   }, []);
 
   const redirectTo404 = () => {
-    if (typeof window !== "undefined" && !hasParent) {
+    if (typeof window !== "undefined") {
       window.location.href = "/404.html";
     }
   }

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -58,6 +58,20 @@ const Edit: () => JSX.Element = () => {
   const [saveState, setSaveState] = useState<SaveState>();
   const [saveStateFetched, setSaveStateFetched] = useState<boolean>(false); // needed because saveState can be empty
   const [devPageSets, setDevPageSets] = useState<any>(undefined);
+  const [hasParent, setHasParent] = useState<boolean>(false);
+
+  useEffect(() => {
+    console.log(window.parent);
+    if (window.parent.name) {
+      setHasParent(true);
+    }
+  }, []);
+
+  const redirectTo404 = () => {
+    if (typeof window !== "undefined") {
+      window.location.href = "/404.html";
+    }
+  }
 
   useEffect(() => {
     if (templateMetadata?.isDevMode) {
@@ -350,7 +364,11 @@ const Edit: () => JSX.Element = () => {
           />
         </DocumentProvider>
       ) : (
-        <LoadingScreen progress={progress} />
+        hasParent ?
+         (
+          <LoadingScreen progress={progress} />
+        ) : 
+        redirectTo404()
       )}
       <Toaster closeButton richColors />
     </>

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -61,14 +61,11 @@ const Edit: () => JSX.Element = () => {
   const [hasParent, setHasParent] = useState<boolean>(true);
 
   useEffect(() => {
-    console.log(window.parent.location.ancestorOrigins);
     if (typeof window !== "undefined") {
-      const ancestors = window.parent.location.ancestorOrigins
-      if (ancestors.length == 0) {
-        console.log("here1");
+      const ancestors = window.parent.location.ancestorOrigins;
+      if (ancestors.length === 0) {
         setHasParent(false);
       } else if (!ancestors[0].includes("pagescdn") || !ancestors[0].includes("yext.com")) {
-        console.log("here");
         setHasParent(false);
       }
     }

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -62,14 +62,15 @@ const Edit: () => JSX.Element = () => {
 
   useEffect(() => {
     if (typeof window !== "undefined") {
+      console.log(window);
       console.log(window.parent);
-      console.log(window.parent[2].location.ancestorOrigins);
-      const ancestors = window.parent[2].location.ancestorOrigins;
-      if (ancestors.length === 0) {
-        setHasParent(false);
-      } else if (!ancestors[0].includes("pagescdn") || !ancestors[0].includes("yext.com")) {
-        setHasParent(false);
-      }
+      //console.log(window.parent[2].location.ancestorOrigins);
+      // const ancestors = window.parent[2].location.ancestorOrigins;
+      // if (ancestors.length === 0) {
+      //   setHasParent(false);
+      // } else if (!ancestors[0].includes("pagescdn") || !ancestors[0].includes("yext.com")) {
+      //   setHasParent(false);
+      // }
     }
   }, []);
 

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -60,11 +60,15 @@ const Edit: () => JSX.Element = () => {
   const [devPageSets, setDevPageSets] = useState<any>(undefined);
   const [hasParent, setHasParent] = useState<boolean>(true);
 
-  console.log(hasParent)
   useEffect(() => {
-    console.log(window.parent);
+    console.log(window.parent.location.ancestorOrigins);
     if (typeof window !== "undefined") {
-      if (window.parent) {
+      const ancestors = window.parent.location.ancestorOrigins
+      if (ancestors.length == 0) {
+        console.log("here1");
+        setHasParent(false);
+      } else if (!ancestors[0].includes("pagescdn") || !ancestors[0].includes("yext.com")) {
+        console.log("here");
         setHasParent(false);
       }
     }

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -58,13 +58,15 @@ const Edit: () => JSX.Element = () => {
   const [saveState, setSaveState] = useState<SaveState>();
   const [saveStateFetched, setSaveStateFetched] = useState<boolean>(false); // needed because saveState can be empty
   const [devPageSets, setDevPageSets] = useState<any>(undefined);
-  const [hasParent, setHasParent] = useState<boolean>(false);
+  const [hasParent, setHasParent] = useState<boolean>(true);
 
   useEffect(() => {
     if (typeof window !== "undefined") {
       const ancestors = window.location.ancestorOrigins;
-      if  (ancestors[0].includes("pagescdn") || ancestors[0].includes("yext.com")) {
-        setHasParent(true);
+      if (ancestors.length === 0) {
+        setHasParent(false);
+      } else if (!ancestors[0].includes("pagescdn") && !ancestors[0].includes("yext.com")) {
+        setHasParent(false);
       }
     }
   }, []);

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -64,7 +64,7 @@ const Edit: () => JSX.Element = () => {
     if (typeof window !== "undefined") {
       console.log(window.parent);
       console.log(window.parent[2].location.ancestorOrigins);
-      const ancestors = window.parent.location.ancestorOrigins;
+      const ancestors = window.parent[2].location.ancestorOrigins;
       if (ancestors.length === 0) {
         setHasParent(false);
       } else if (!ancestors[0].includes("pagescdn") || !ancestors[0].includes("yext.com")) {

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -64,19 +64,18 @@ const Edit: () => JSX.Element = () => {
     if (typeof window !== "undefined") {
       console.log(window);
       console.log(window.parent);
-      //console.log(window.parent[2].location.ancestorOrigins);
-      // const ancestors = window.parent[2].location.ancestorOrigins;
-      // if (ancestors.length === 0) {
-      //   setHasParent(false);
-      // } else if (!ancestors[0].includes("pagescdn") || !ancestors[0].includes("yext.com")) {
-      //   setHasParent(false);
-      // }
+      const ancestors = window.location.ancestorOrigins;
+      if (ancestors.length === 0) {
+        setHasParent(false);
+      } else if (!ancestors[0].includes("pagescdn") || !ancestors[0].includes("yext.com")) {
+        setHasParent(false);
+      }
     }
   }, []);
 
   const redirectTo404 = () => {
     if (typeof window !== "undefined") {
-      //window.location.href = "/404.html";
+      window.location.href = "/404.html";
     }
   }
 

--- a/src/templates/edit.tsx
+++ b/src/templates/edit.tsx
@@ -41,6 +41,12 @@ export type PuckInitialHistory = {
   index: number;
 };
 
+const ParentStatus = {
+  LOADED: "loaded",
+  NULL: "null",
+  PENDING: "pending",
+}
+
 // Render the editor
 const Edit: () => JSX.Element = () => {
   const [puckData, setPuckData] = useState<Data>();
@@ -58,23 +64,23 @@ const Edit: () => JSX.Element = () => {
   const [saveState, setSaveState] = useState<SaveState>();
   const [saveStateFetched, setSaveStateFetched] = useState<boolean>(false); // needed because saveState can be empty
   const [devPageSets, setDevPageSets] = useState<any>(undefined);
-  const [hasParent, setHasParent] = useState<boolean>(true);
+  const [parentStatus, setParentStatus] = useState<string>(ParentStatus.PENDING);
 
   useEffect(() => {
     if (typeof window !== "undefined") {
       const ancestors = window.location.ancestorOrigins;
       if (ancestors.length === 0) {
-        setHasParent(false);
+        setParentStatus(ParentStatus.NULL);
       } else if (!ancestors[0].includes("pagescdn") && !ancestors[0].includes("yext.com")) {
-        setHasParent(false);
+        setParentStatus(ParentStatus.NULL);
+      } else {
+        setParentStatus(ParentStatus.LOADED);
       }
     }
   }, []);
 
   const redirectTo404 = () => {
-    if (typeof window !== "undefined") {
-      window.location.href = "/404.html";
-    }
+    window.location.href = "/404.html";
   }
 
   useEffect(() => {
@@ -369,11 +375,11 @@ const Edit: () => JSX.Element = () => {
         </DocumentProvider>
       ) : 
       (
-        hasParent && typeof window !== "undefined" ?
+        parentStatus === ParentStatus.LOADED ?
          (
           <LoadingScreen progress={progress} />
         ) : 
-        !hasParent && redirectTo404()
+        parentStatus === ParentStatus.NULL && redirectTo404()
       )}
       <Toaster closeButton richColors />
     </>


### PR DESCRIPTION
Verified that VE works in storm in multiple envs (where ancestor origin contains pagescdn or yext.com), verified that running VE on localhost redirects to 404 and that no content loads prior to the redirect.