### PR TITLE
fix: disable links in Puck preview

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -18,7 +18,12 @@ const navigation: CTA[] = [
   { link: "#", label: "FAQs" },
 ];
 
-const Footer = () => {
+type FooterProps = {
+  isEditing: boolean;
+}
+
+const Footer = (props : FooterProps) => {
+  const { isEditing } = props;
   return (
     <FooterLayout
       copyrightMessage={"All Rights Reserved."}
@@ -28,6 +33,7 @@ const Footer = () => {
       facebook="#"
       instagram="#"
       footerLinks={navigation}
+      isEditing={isEditing}
     />
   );
 };
@@ -40,6 +46,7 @@ interface FooterLayoutProps {
   facebook?: string;
   instagram?: string;
   footerLinks: CTA[];
+  isEditing: boolean;
 }
 
 const FooterLayout = (props: FooterLayoutProps) => {
@@ -51,6 +58,7 @@ const FooterLayout = (props: FooterLayoutProps) => {
     facebook,
     instagram,
     footerLinks,
+    isEditing,
   } = props;
 
   const socialLinks = [
@@ -91,6 +99,7 @@ const FooterLayout = (props: FooterLayoutProps) => {
               cta={link}
               className="font-bold hover:underline md:px-4"
               eventName={`link${i}`}
+              style={{pointerEvents: isEditing && "none"}}
             />
           ))}
         </div>
@@ -101,6 +110,7 @@ const FooterLayout = (props: FooterLayoutProps) => {
                 key={i}
                 href={socialLink.link}
                 className="hover:text-gray-300"
+                style={{pointerEvents: isEditing && "none"}}
               >
                 {socialLink.label}
               </Link>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,9 +3,9 @@ import logo from "../assets/logo.png";
 import "./index.css";
 
 const navigation: CTA[] = [
-  { link: "/", label: "Restaurants" },
-  { link: "/", label: "Blog" },
-  { link: "/", label: "Support" },
+  { link: "#", label: "Restaurants" },
+  { link: "#", label: "Blog" },
+  { link: "#", label: "Support" },
 ];
 
 const Header = () => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,18 +8,24 @@ const navigation: CTA[] = [
   { link: "#", label: "Support" },
 ];
 
-const Header = () => {
-  return <HeaderLayout links={navigation} logo={logo} />;
+type HeaderProps = {
+  isEditing: boolean;
+}
+
+const Header = (props: HeaderProps) => {
+  const { isEditing } = props;
+  return <HeaderLayout links={navigation} logo={logo} isEditing={isEditing} />;
 };
 
 type HeaderLayoutProps = {
+  isEditing: boolean;
   links: CTA[];
   logo?: string;
   logoLink?: string;
 };
 
 const HeaderLayout = (props: HeaderLayoutProps) => {
-  const { logo } = props;
+  const { logo, isEditing } = props;
 
   return (
     <header className=" w-full bg-white components">
@@ -32,7 +38,7 @@ const HeaderLayout = (props: HeaderLayoutProps) => {
                 key={item.label?.toString()}
                 className="cursor-pointer font-bold text-primary hover:text-primary/90"
               >
-                <Link cta={item} eventName={`link${idx}`} />
+                <Link cta={item} eventName={`link${idx}`} style={{pointerEvents: isEditing && "none"}} />
               </li>
             ))}
           </ul>

--- a/src/ve.config.tsx
+++ b/src/ve.config.tsx
@@ -42,12 +42,12 @@ export const locationConfig: Config<LocationProps> = {
     FeaturedItems,
   },
   root: {
-    render: ({ children }) => {
+    render: ({ children, puck: {isEditing} }) => {
       return (
         <>
-          <Header />
+          <Header isEditing={isEditing} />
           {children}
-          <Footer />
+          <Footer isEditing={isEditing} />
         </>
       );
     },


### PR DESCRIPTION
Passes the isEditing prop from Puck down to the header and footer, which then conditional disable links.