### PR TITLE
fix: unique key for email in storeInfoCard

### DIFF
--- a/src/components/StoreInfoCard.tsx
+++ b/src/components/StoreInfoCard.tsx
@@ -104,7 +104,7 @@ const StoreInfoCard = ({ heading, alignment }: StoreInfoCardProps) => {
                 {emails.map((email: any) => (
                   <div
                     className="pt-2.5 gap-x-1.5 flex flex-row items-center"
-                    key="email"
+                    key={email}
                   >
                     <MdOutlineEmail />
                     <Link


### PR DESCRIPTION
This fixes the console error for duplicate key email

The rest of the visual editor still works as expected