### PR TITLE
chore: update cac for themes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,7 @@ siteStream:
   entityId: site
   fields:
     - defaultLayouts.visualConfiguration
+    - c_theme.c_themeConfiguration
   localization:
     locales:
       - en

--- a/platform-config/config/content/settings.json
+++ b/platform-config/config/content/settings.json
@@ -9,6 +9,7 @@
     },
     {
       "entityType": "site",
+      "defaultFieldEligibilityGroup": "site.default",
       "disabled": false
     },
     {
@@ -22,6 +23,11 @@
     {
       "entityType": "product",
       "defaultFieldEligibilityGroup": "product.default",
+      "disabled": false
+    },
+    {
+      "entityType": "ce_pagesTheme",
+      "defaultFieldEligibilityGroup": "ce_pagesTheme.default",
       "disabled": false
     }
   ]

--- a/platform-config/config/themes/entity-type/pagesTheme.json
+++ b/platform-config/config/themes/entity-type/pagesTheme.json
@@ -1,0 +1,7 @@
+{
+  "$id": "ce_pagesTheme",
+  "$schema": "https://schema.yext.com/config/km/entity-type/v2",
+  "description": "Use this entity type to store theme data for Pages in Theme Manager.",
+  "displayName": "Pages Theme",
+  "pluralDisplayName": "Pages Themes"
+}

--- a/platform-config/config/themes/field-eligibility-group/pagesTheme.default.json
+++ b/platform-config/config/themes/field-eligibility-group/pagesTheme.default.json
@@ -1,0 +1,11 @@
+{
+  "$id": "ce_pagesTheme.default",
+  "$schema": "https://schema.yext.com/config/km/field-eligibility-group/v1",
+  "name": "Pages Theme-default",
+  "entityType": "ce_pagesTheme",
+  "fields": [
+    "c_sites",
+    "c_themeConfiguration"
+  ],
+  "required": []
+}

--- a/platform-config/config/themes/field-presentation/pagesTheme.json
+++ b/platform-config/config/themes/field-presentation/pagesTheme.json
@@ -1,0 +1,42 @@
+{
+  "$id": "ce_pagesTheme",
+  "$schema": "https://schema.yext.com/config/km/field-presentation/v1",
+  "entityType": "ce_pagesTheme",
+  "displayName": "Pages Theme",
+  "presentationEntries": [
+    {
+      "displayName": "Content",
+      "entryType": "DIVIDER"
+    },
+    {
+      "displayName": "Core Information",
+      "entryType": "SECTION",
+      "fields": [
+        {
+          "id": "name",
+          "visibleOnAdd": true
+        },
+        {
+          "id": "entityId",
+          "visibleOnAdd": true
+        }
+      ]
+    },
+    {
+      "displayName": "Other",
+      "entryType": "DIVIDER"
+    },
+    {
+      "displayName": "Internal Use Only",
+      "entryType": "SECTION",
+      "fields": [
+        {
+          "id": "folder"
+        },
+        {
+          "id": "labels"
+        }
+      ]
+    }
+  ]
+}

--- a/platform-config/config/themes/field-type/themeConfiguration.json
+++ b/platform-config/config/themes/field-type/themeConfiguration.json
@@ -1,0 +1,23 @@
+{
+  "$id": "c_themeConfiguration",
+  "$schema": "https://schema.yext.com/config/km/field-type/v1",
+  "displayName": "Theme Configuration",
+  "type": {
+    "structType": {
+      "property": [
+        {
+          "name": "data",
+          "displayName": "Data",
+          "isRequired": true,
+          "typeId": "string",
+          "type": {
+            "stringType": {
+              "stereotype": "MULTILINE",
+              "maxLength": 100000
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/platform-config/config/themes/field/sites.json
+++ b/platform-config/config/themes/field/sites.json
@@ -1,0 +1,19 @@
+{
+  "$id": "c_sites",
+  "$schema": "https://schema.yext.com/config/km/field/v1",
+  "displayName": "Sites",
+  "group": "NONE",
+  "localization": "PRIMARY_ONLY",
+  "type": {
+    "listType": {
+      "typeId": "entityReference",
+      "type": {
+        "entityReferenceType": {
+          "relatedFieldId": "c_theme",
+          "type": "TWO_WAY"
+        }
+      }
+    }
+  },
+  "typeId": "list"
+}

--- a/platform-config/config/themes/field/theme.json
+++ b/platform-config/config/themes/field/theme.json
@@ -1,0 +1,19 @@
+{
+  "$id": "c_theme",
+  "$schema": "https://schema.yext.com/config/km/field/v1",
+  "displayName": "Theme",
+  "group": "NONE",
+  "localization": "PRIMARY_ONLY",
+  "type": {
+    "listType": {
+      "typeId": "entityReference",
+      "type": {
+        "entityReferenceType": {
+          "relatedFieldId": "c_sites",
+          "type": "TWO_WAY"
+        }
+      }
+    }
+  },
+  "typeId": "list"
+}

--- a/platform-config/config/themes/field/themeConfiguration.json
+++ b/platform-config/config/themes/field/themeConfiguration.json
@@ -1,0 +1,8 @@
+{
+  "$id": "c_themeConfiguration",
+  "$schema": "https://schema.yext.com/config/km/field/v1",
+  "displayName": "Theme Configuration",
+  "group": "NONE",
+  "localization": "PRIMARY_ONLY",
+  "typeId": "c_themeConfiguration"
+}

--- a/platform-config/entities/default-theme.json
+++ b/platform-config/entities/default-theme.json
@@ -1,0 +1,15 @@
+{
+  "$id": "default-theme",
+  "$schema": "https://schema.yext.com/config/km/entity/v1",
+  "primaryLocale": "en",
+  "content": {
+    "c_sites": [
+      "site"
+    ],
+    "c_themeConfiguration": {"data": "{}"},
+    "name": "Default Theme"
+  },
+  "entityType": "ce_pagesTheme",
+  "folder": "yext/root",
+  "labels": []
+}

--- a/platform-config/entities/site.json
+++ b/platform-config/entities/site.json
@@ -6,6 +6,9 @@
     "defaultLayouts": [
       "storePagesLayout"
     ],
+    "c_theme": [
+      "default-theme"
+    ],
     "name": "Site"
   },
   "entityType": "site",


### PR DESCRIPTION
- adds a custom entity type ce_pagesTheme
  - adds a custom field c_themeConfiguration which holds {data: string}
- adds two-way relationship field between Site and Pages Theme
- adds a Default Theme entity linked to the default site
  - holds {data: "{}"} i.e. use developer-defined defaults

Tested via `yext resources apply` onto a fresh account. Did not test via the Getting Started flow because that is currently broken due to site id work
 
The theme becomes available in templates via `document._site.c_theme[0].c_themeConfiguration.data`