### PR TITLE
fix: fix fontSize for FAQ and Banner components

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -4,7 +4,9 @@ import {
   YextEntityFieldSelector,
   Body,
   BodyProps,
-  useDocument
+  useDocument,
+    NumberOrDefault,
+  NumberFieldWithDefaultOption
 } from "@yext/visual-editor";
 import { ComponentConfig, Fields } from "@measured/puck";
 import { config } from "../templates/location";
@@ -13,7 +15,7 @@ import { LocationStream } from "../types/autogen";
 export type BannerProps = {
   text: YextEntityField<string>;
   textAlignment: "justify-end" | "justify-start" | "justify-center";
-  textSize: BodyProps["size"];
+  fontSize: NumberOrDefault;
   fontWeight: BodyProps["weight"];
   textColor: BodyProps["color"];
   backgroundColor: "bg-white" | "bg-palette-primary" | "bg-palette-secondary";
@@ -35,15 +37,10 @@ const bannerFields: Fields<BannerProps> = {
       { label: "Right", value: "justify-end" },
     ],
   },
-  textSize: {
-    label: "Text Size",
-    type: "radio",
-    options: [
-      { label: "Small", value: "small" },
-      { label: "Base", value: "base" },
-      { label: "Large", value: "large" },
-    ],
-  },
+  fontSize: NumberFieldWithDefaultOption({
+    label: "Font Size",
+    defaultCustomValue: 16,
+  }),
   fontWeight: {
     label: "Font Weight",
     type: "radio",
@@ -75,7 +72,7 @@ const bannerFields: Fields<BannerProps> = {
 const Banner = ({
   text,
   textAlignment,
-  textSize,
+  fontSize,
   fontWeight,
   textColor,
   backgroundColor,
@@ -84,7 +81,12 @@ const Banner = ({
   return (
     <div className={`Banner ${backgroundColor} components px-4 md:px-20 py-6`}>
       <div className={`flex ${textAlignment} items-center`}>
-        <Body color={textColor} weight={fontWeight} size={textSize}>
+        <Body color={textColor} weight={fontWeight}                       style={{
+          fontSize:
+              fontSize === "default"
+                  ? undefined
+                  : fontSize + "px",
+        }}>
           {resolveYextEntityField(document, text)}
         </Body>
       </div>
@@ -101,7 +103,7 @@ export const BannerComponent: ComponentConfig<BannerProps> = {
       constantValueEnabled: true
     },
     textAlignment: "justify-center",
-    textSize: "base",
+    fontSize: "default",
     fontWeight: "default",
     textColor: "default",
     backgroundColor: "bg-white",

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -5,8 +5,8 @@ import {
   Body,
   BodyProps,
   useDocument,
-    NumberOrDefault,
-  NumberFieldWithDefaultOption
+  NumberOrDefault,
+  NumberFieldWithDefaultOption,
 } from "@yext/visual-editor";
 import { ComponentConfig, Fields } from "@measured/puck";
 import { config } from "../templates/location";
@@ -81,12 +81,13 @@ const Banner = ({
   return (
     <div className={`Banner ${backgroundColor} components px-4 md:px-20 py-6`}>
       <div className={`flex ${textAlignment} items-center`}>
-        <Body color={textColor} weight={fontWeight}                       style={{
-          fontSize:
-              fontSize === "default"
-                  ? undefined
-                  : fontSize + "px",
-        }}>
+        <Body
+          color={textColor}
+          weight={fontWeight}
+          style={{
+            fontSize: fontSize === "default" ? undefined : fontSize + "px",
+          }}
+        >
           {resolveYextEntityField(document, text)}
         </Body>
       </div>
@@ -100,7 +101,7 @@ export const BannerComponent: ComponentConfig<BannerProps> = {
     text: {
       field: "",
       constantValue: "Banner Text",
-      constantValueEnabled: true
+      constantValueEnabled: true,
     },
     textAlignment: "justify-center",
     fontSize: "default",

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -11,7 +11,9 @@ import {
   Heading,
   HeadingProps,
   Section,
-  useDocument
+  useDocument,
+  NumberOrDefault,
+  NumberFieldWithDefaultOption,
 } from "@yext/visual-editor";
 import { config } from "../templates/location";
 import { LocationStream, Cta, ComplexImage } from "../types/autogen";
@@ -26,19 +28,19 @@ export type CardProps = {
     text: {
       entityField: YextEntityField<string>;
     };
-    size: HeadingProps["size"];
+    fontSize: NumberOrDefault;
     color: HeadingProps["color"];
   };
   subheading: {
     text: string;
-    size: BodyProps["size"];
+    fontSize: NumberOrDefault;
     weight: BodyProps["weight"];
   };
   body: {
     text: {
       entityField: YextEntityField<string>;
     };
-    size: BodyProps["size"];
+    fontSize: NumberOrDefault;
     weight: BodyProps["weight"];
   };
   cta: {
@@ -83,14 +85,10 @@ const cardFields: Fields<CardProps> = {
           }),
         },
       },
-      size: {
-        label: "Size",
-        type: "radio",
-        options: [
-          { label: "Section", value: "section" },
-          { label: "Subheading", value: "subheading" },
-        ],
-      },
+      fontSize: NumberFieldWithDefaultOption({
+        label: "Font Size",
+        defaultCustomValue: 24,
+      }),
       color: {
         label: "Color",
         type: "radio",
@@ -110,15 +108,10 @@ const cardFields: Fields<CardProps> = {
         label: "Text",
         type: "text",
       },
-      size: {
-        label: "Size",
-        type: "radio",
-        options: [
-          { label: "Small", value: "small" },
-          { label: "Base", value: "base" },
-          { label: "Large", value: "large" },
-        ],
-      },
+      fontSize: NumberFieldWithDefaultOption({
+        label: "Font Size",
+        defaultCustomValue: 16,
+      }),
       weight: {
         label: "Weight",
         type: "radio",
@@ -145,15 +138,10 @@ const cardFields: Fields<CardProps> = {
           }),
         },
       },
-      size: {
-        label: "Size",
-        type: "radio",
-        options: [
-          { label: "Small", value: "small" },
-          { label: "Base", value: "base" },
-          { label: "Large", value: "large" },
-        ],
-      },
+      fontSize: NumberFieldWithDefaultOption({
+        label: "Font Size",
+        defaultCustomValue: 16,
+      }),
       weight: {
         label: "Weight",
         type: "radio",
@@ -206,7 +194,7 @@ export const Card = ({
   // The null checks on the following lines are only necessary when upgrading a pre-existing field to use a mappable entity field
   const image = resolveYextEntityField<ComplexImage>(
     document,
-    imageField?.photo?.entityField
+    imageField?.photo?.entityField,
   )?.image;
   const cta = resolveYextEntityField<Cta>(document, ctaField?.entityField);
 
@@ -230,17 +218,38 @@ export const Card = ({
         />
       )}
       <div className="flex flex-col gap-y-3 p-8">
-        <Heading level={2} size={heading.size} color={heading.color}>
+        <Heading
+          level={2}
+          style={{
+            fontSize:
+              heading.fontSize === "default"
+                ? undefined
+                : heading.fontSize + "px",
+          }}
+          color={heading.color}
+        >
           {resolveYextEntityField(document, heading.text.entityField)}
         </Heading>
         <Body
           className="line-clamp-1"
           weight={subheading.weight}
-          size={subheading.size}
+          style={{
+            fontSize:
+              subheading.fontSize === "default"
+                ? undefined
+                : subheading.fontSize + "px",
+          }}
         >
           {subheading.text}
         </Body>
-        <Body className="line-clamp-5" weight={body.weight} size={body.size}>
+        <Body
+          className="line-clamp-5"
+          weight={body.weight}
+          style={{
+            fontSize:
+              body.fontSize === "default" ? undefined : body.fontSize + "px",
+          }}
+        >
           {resolveYextEntityField(document, body.text.entityField)}
         </Body>
         {cta && (
@@ -262,7 +271,7 @@ export const CardComponent: ComponentConfig<CardProps> = {
       photo: {
         entityField: {
           field: "",
-          constantValue: ""
+          constantValue: "",
         },
       },
     },
@@ -271,15 +280,15 @@ export const CardComponent: ComponentConfig<CardProps> = {
         entityField: {
           field: "",
           constantValue: "Heading Text",
-          constantValueEnabled: true
+          constantValueEnabled: true,
         },
       },
-      size: "section",
+      fontSize: "default",
       color: "default",
     },
     subheading: {
       text: "subheading",
-      size: "small",
+      fontSize: "default",
       weight: "default",
     },
     body: {
@@ -287,16 +296,16 @@ export const CardComponent: ComponentConfig<CardProps> = {
         entityField: {
           field: "",
           constantValue: "Body Text",
-          constantValueEnabled: true
+          constantValueEnabled: true,
         },
       },
-      size: "base",
+      fontSize: "default",
       weight: "default",
     },
     cta: {
       entityField: {
         field: "",
-        constantValue: ""
+        constantValue: "",
       },
     },
     alignment: "items-center",

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -7,20 +7,30 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "./atoms/accordion";
-import { EntityField, Body, BodyProps, Heading, HeadingProps, Section, useDocument } from "@yext/visual-editor";
+import {
+  EntityField,
+  Body,
+  BodyProps,
+  Heading,
+  HeadingProps,
+  Section,
+  useDocument,
+  NumberOrDefault,
+  NumberFieldWithDefaultOption,
+} from "@yext/visual-editor";
 
 export type FAQProps = {
   sectionTitle: {
     text: string;
-    size: HeadingProps["size"];
+    fontSize: NumberOrDefault;
     color: HeadingProps["color"];
   };
   question: {
-    size: HeadingProps["size"];
+    fontSize: NumberOrDefault;
     color: HeadingProps["color"];
   };
   answer: {
-    size: BodyProps["size"];
+    fontSize: NumberOrDefault;
     weight: BodyProps["weight"];
   };
 };
@@ -34,14 +44,10 @@ const FAQFields: Fields<FAQProps> = {
         label: "Text",
         type: "text",
       },
-      size: {
-        label: "Size",
-        type: "radio",
-        options: [
-          { label: "Section", value: "section" },
-          { label: "Subheading", value: "subheading" },
-        ],
-      },
+      fontSize: NumberFieldWithDefaultOption({
+        label: "Font Size",
+        defaultCustomValue: 48,
+      }),
       color: {
         label: "Color",
         type: "radio",
@@ -57,14 +63,10 @@ const FAQFields: Fields<FAQProps> = {
     type: "object",
     label: "Question",
     objectFields: {
-      size: {
-        label: "Size",
-        type: "radio",
-        options: [
-          { label: "Section", value: "section" },
-          { label: "Subheading", value: "subheading" },
-        ],
-      },
+      fontSize: NumberFieldWithDefaultOption({
+        label: "Font Size",
+        defaultCustomValue: 48,
+      }),
       color: {
         label: "Color",
         type: "radio",
@@ -80,15 +82,10 @@ const FAQFields: Fields<FAQProps> = {
     type: "object",
     label: "Answer",
     objectFields: {
-      size: {
-        label: "Size",
-        type: "radio",
-        options: [
-          { label: "Small", value: "small" },
-          { label: "Base", value: "base" },
-          { label: "Large", value: "large" },
-        ],
-      },
+      fontSize: NumberFieldWithDefaultOption({
+        label: "Font Size",
+        defaultCustomValue: 48,
+      }),
       weight: {
         label: "Weight",
         type: "radio",
@@ -108,8 +105,13 @@ const FAQCard = ({ sectionTitle, question, answer }: FAQProps) => {
     <Section className="flex flex-col justify-center bg-white components">
       {sectionTitle && (
         <Heading
+          style={{
+            fontSize:
+              sectionTitle.fontSize === "default"
+                ? undefined
+                : sectionTitle.fontSize + "px",
+          }}
           level={1}
-          size={sectionTitle.size}
           color={sectionTitle.color}
           className="text-center"
         >
@@ -128,17 +130,30 @@ const FAQCard = ({ sectionTitle, question, answer }: FAQProps) => {
                   <AccordionTrigger>
                     <Heading
                       level={1}
-                      size={question.size}
+                      style={{
+                        fontSize:
+                          question.fontSize === "default"
+                            ? undefined
+                            : question.fontSize + "px",
+                      }}
                       color={question.color}
                     >
                       {faqItem.question}
                     </Heading>
                   </AccordionTrigger>
                   <AccordionContent>
-                    <Body size={answer.size} weight={answer.weight}>
+                    <Body
+                      style={{
+                        fontSize:
+                          answer.fontSize === "default"
+                            ? undefined
+                            : answer.fontSize + "px",
+                      }}
+                      weight={answer.weight}
+                    >
                       <LexicalRichText
                         nodeClassNames={{
-                          text: { bold: answer.weight!, base: answer.size! },
+                          text: { bold: answer.weight! },
                         }}
                         serializedAST={JSON.stringify(faqItem.answerV2.json)}
                       />
@@ -159,15 +174,15 @@ export const FAQComponent: ComponentConfig<FAQProps> = {
   defaultProps: {
     sectionTitle: {
       text: "Frequently Asked Questions",
-      size: "section",
+      fontSize: "default",
       color: "default",
     },
     question: {
-      size: "subheading",
+      fontSize: "default",
       color: "default",
     },
     answer: {
-      size: "base",
+      fontSize: "default",
       weight: "default",
     },
   },

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -84,7 +84,7 @@ const FAQFields: Fields<FAQProps> = {
     objectFields: {
       fontSize: NumberFieldWithDefaultOption({
         label: "Font Size",
-        defaultCustomValue: 48,
+        defaultCustomValue: 16,
       }),
       weight: {
         label: "Weight",

--- a/src/components/FeaturedItems.tsx
+++ b/src/components/FeaturedItems.tsx
@@ -1,23 +1,35 @@
 import { ComponentConfig, Fields } from "@measured/puck";
 import { LocationStream } from "../types/autogen";
-import { EntityField, Body, BodyProps, CTA, CTAProps, Heading, HeadingProps, Section, useDocument } from "@yext/visual-editor";
+import {
+  EntityField,
+  Body,
+  BodyProps,
+  CTA,
+  CTAProps,
+  Heading,
+  HeadingProps,
+  Section,
+  useDocument,
+  NumberOrDefault,
+  NumberFieldWithDefaultOption,
+} from "@yext/visual-editor";
 
 export type FeaturedItemsProps = {
   heading: {
-    size: HeadingProps["size"];
+    fontSize: NumberOrDefault;
     color: HeadingProps["color"];
   };
   cards: {
     heading: {
-      size: HeadingProps["size"];
+      fontSize: NumberOrDefault;
       color: HeadingProps["color"];
     };
     subheading: {
-      size: BodyProps["size"];
+      fontSize: NumberOrDefault;
       weight: BodyProps["weight"];
     };
     body: {
-      size: BodyProps["size"];
+      fontSize: NumberOrDefault;
       weight: BodyProps["weight"];
     };
     cta?: {
@@ -31,14 +43,10 @@ const featuredItemsFields: Fields<FeaturedItemsProps> = {
     type: "object",
     label: "Heading",
     objectFields: {
-      size: {
-        label: "Size",
-        type: "radio",
-        options: [
-          { label: "Section", value: "section" },
-          { label: "Subheading", value: "subheading" },
-        ],
-      },
+      fontSize: NumberFieldWithDefaultOption({
+        label: "Font Size",
+        defaultCustomValue: 48,
+      }),
       color: {
         label: "Color",
         type: "radio",
@@ -58,14 +66,10 @@ const featuredItemsFields: Fields<FeaturedItemsProps> = {
         type: "object",
         label: "Heading",
         objectFields: {
-          size: {
-            label: "Size",
-            type: "radio",
-            options: [
-              { label: "Section", value: "section" },
-              { label: "Subheading", value: "subheading" },
-            ],
-          },
+          fontSize: NumberFieldWithDefaultOption({
+            label: "Font Size",
+            defaultCustomValue: 24,
+          }),
           color: {
             label: "Color",
             type: "radio",
@@ -81,15 +85,10 @@ const featuredItemsFields: Fields<FeaturedItemsProps> = {
         type: "object",
         label: "Subheading",
         objectFields: {
-          size: {
-            label: "Size",
-            type: "radio",
-            options: [
-              { label: "Small", value: "small" },
-              { label: "Base", value: "base" },
-              { label: "Large", value: "large" },
-            ],
-          },
+          fontSize: NumberFieldWithDefaultOption({
+            label: "Font Size",
+            defaultCustomValue: 16,
+          }),
           weight: {
             label: "Weight",
             type: "radio",
@@ -104,15 +103,10 @@ const featuredItemsFields: Fields<FeaturedItemsProps> = {
         type: "object",
         label: "Body",
         objectFields: {
-          size: {
-            label: "Size",
-            type: "radio",
-            options: [
-              { label: "Small", value: "small" },
-              { label: "Base", value: "base" },
-              { label: "Large", value: "large" },
-            ],
-          },
+          fontSize: NumberFieldWithDefaultOption({
+            label: "Font Size",
+            defaultCustomValue: 16,
+          }),
           weight: {
             label: "Weight",
             type: "radio",
@@ -150,7 +144,15 @@ const FeaturedItems = ({ heading, cards }: FeaturedItemsProps) => {
           displayName="Product Section Title"
           fieldId="c_productSection.sectionTitle"
         >
-          <Heading size={heading.size} color={heading.color}>
+          <Heading
+            style={{
+              fontSize:
+                heading.fontSize === "default"
+                  ? undefined
+                  : heading.fontSize + "px",
+            }}
+            color={heading.color}
+          >
             {productSection.sectionTitle}
           </Heading>
         </EntityField>
@@ -179,17 +181,17 @@ const FeaturedItems = ({ heading, cards }: FeaturedItemsProps) => {
                   }}
                   heading={{
                     text: product.name,
-                    size: cards.heading.size,
+                    size: cards.heading.fontSize,
                     color: cards.heading.color,
                   }}
                   subheading={{
                     text: product.c_productPromo,
-                    size: cards.subheading.size,
+                    size: cards.subheading.fontSize,
                     weight: cards.subheading.weight,
                   }}
                   body={{
                     text: product.c_description ?? "",
-                    size: cards.body.size,
+                    size: cards.body.fontSize,
                     weight: cards.body.weight,
                   }}
                   image={{
@@ -209,20 +211,20 @@ export const FeaturedItemsComponent: ComponentConfig<FeaturedItemsProps> = {
   fields: featuredItemsFields,
   defaultProps: {
     heading: {
-      size: "section",
+      fontSize: "default",
       color: "default",
     },
     cards: {
       heading: {
-        size: "section",
+        fontSize: "default",
         color: "default",
       },
       subheading: {
-        size: "small",
+        fontSize: "default",
         weight: "default",
       },
       body: {
-        size: "base",
+        fontSize: "default",
         weight: "default",
       },
     },
@@ -237,17 +239,17 @@ type FeaturedItemCardProps = {
   };
   heading: {
     text: string;
-    size: HeadingProps["size"];
+    size: NumberOrDefault;
     color: HeadingProps["color"];
   };
   subheading: {
     text: string;
-    size: BodyProps["size"];
+    size: NumberOrDefault;
     weight: BodyProps["weight"];
   };
   body: {
     text: string;
-    size: BodyProps["size"];
+    size: NumberOrDefault;
     weight: BodyProps["weight"];
   };
   cta?: {
@@ -284,17 +286,35 @@ const FeaturedItemCard = ({
         />
       )}
       <div className="flex flex-col gap-y-3 p-8">
-        <Heading level={2} size={heading.size} color={heading.color}>
+        <Heading
+          level={2}
+          style={{
+            fontSize:
+              heading.size === "default" ? undefined : heading.size + "px",
+          }}
+          color={heading.color}
+        >
           {heading.text}
         </Heading>
         <Body
           className="line-clamp-1"
           weight={subheading.weight}
-          size={subheading.size}
+          style={{
+            fontSize:
+              subheading.size === "default"
+                ? undefined
+                : subheading.size + "px",
+          }}
         >
           {subheading.text}
         </Body>
-        <Body className="line-clamp-5" weight={body.weight} size={body.size}>
+        <Body
+          className="line-clamp-5"
+          weight={body.weight}
+          style={{
+            fontSize: body.size === "default" ? undefined : body.size + "px",
+          }}
+        >
           {body.text}
         </Body>
         {cta && (


### PR DESCRIPTION
Font size now updates properly in the FAQ, Banner, Card, and Featured Items components

Uses the new NumberOrDefault field from visual-editor