### PR TITLE
fix: component breadcrumbs

### DIFF
--- a/src/ve.config.tsx
+++ b/src/ve.config.tsx
@@ -84,7 +84,7 @@ export const locationConfig: Config<LocationProps> = {
       return (
         <>
           <DropZone zone="header" allow={["Header"]} />
-          <DropZone zone="content" disallow={["Header", "Footer"]} />
+          <DropZone zone="default-zone" disallow={["Header", "Footer"]} />
           <DropZone zone="footer" allow={["Footer"]} />
         </>
       );


### PR DESCRIPTION
`default-zone` is a special keyword in puck that renders this dropzone as a child of the root, so it's components have the link back to Page (the meta fields) in the breadcrumbs

![Screenshot 2025-01-10 at 10 15 48 AM](https://github.com/user-attachments/assets/371d6a8f-2248-47e9-8692-af7af2a032f6)
