### PR TITLE
feat: add dev template

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@vitejs/plugin-react": "^4.2.1",
         "@yext/pages": "1.2.0-beta.4",
         "@yext/pages-components": "^1.0.2",
-        "@yext/visual-editor": "0.0.22",
+        "@yext/visual-editor": "https://github.com/jwartofsky-yext/publicAssets/raw/refs/heads/main/VE_LocalDevMode.tgz",
         "autoprefixer": "^10.4.8",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-react": "^7.31.7",
@@ -103,180 +103,180 @@
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.18.0.tgz",
-      "integrity": "sha512-DLIrAukjsSrdMNNDx1ZTks72o4RH/1kOn8Wx5zZm8nnqFexG+JzY4SANnCNEjnFQPJTTvC+KpgiNW/CP2lumng==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.19.0.tgz",
+      "integrity": "sha512-dMHwy2+nBL0SnIsC1iHvkBao64h4z+roGelOz11cxrDBrAdASxLxmfVMop8gmodQ2yZSacX0Rzevtxa+9SqxCw==",
       "dev": true,
       "dependencies": {
-        "@algolia/client-common": "5.18.0",
-        "@algolia/requester-browser-xhr": "5.18.0",
-        "@algolia/requester-fetch": "5.18.0",
-        "@algolia/requester-node-http": "5.18.0"
+        "@algolia/client-common": "5.19.0",
+        "@algolia/requester-browser-xhr": "5.19.0",
+        "@algolia/requester-fetch": "5.19.0",
+        "@algolia/requester-node-http": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.18.0.tgz",
-      "integrity": "sha512-0VpGG2uQW+h2aejxbG8VbnMCQ9ary9/ot7OASXi6OjE0SRkYQ/+pkW+q09+IScif3pmsVVYggmlMPtAsmYWHng==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.19.0.tgz",
+      "integrity": "sha512-CDW4RwnCHzU10upPJqS6N6YwDpDHno7w6/qXT9KPbPbt8szIIzCHrva4O9KIfx1OhdsHzfGSI5hMAiOOYl4DEQ==",
       "dev": true,
       "dependencies": {
-        "@algolia/client-common": "5.18.0",
-        "@algolia/requester-browser-xhr": "5.18.0",
-        "@algolia/requester-fetch": "5.18.0",
-        "@algolia/requester-node-http": "5.18.0"
+        "@algolia/client-common": "5.19.0",
+        "@algolia/requester-browser-xhr": "5.19.0",
+        "@algolia/requester-fetch": "5.19.0",
+        "@algolia/requester-node-http": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.18.0.tgz",
-      "integrity": "sha512-X1WMSC+1ve2qlMsemyTF5bIjwipOT+m99Ng1Tyl36ZjQKTa54oajBKE0BrmM8LD8jGdtukAgkUhFoYOaRbMcmQ==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.19.0.tgz",
+      "integrity": "sha512-2ERRbICHXvtj5kfFpY5r8qu9pJII/NAHsdgUXnUitQFwPdPL7wXiupcvZJC7DSntOnE8AE0lM7oDsPhrJfj5nQ==",
       "dev": true,
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.18.0.tgz",
-      "integrity": "sha512-FAJRNANUOSs/FgYOJ/Njqp+YTe4TMz2GkeZtfsw1TMiA5mVNRS/nnMpxas9771aJz7KTEWvK9GwqPs0K6RMYWg==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.19.0.tgz",
+      "integrity": "sha512-xPOiGjo6I9mfjdJO7Y+p035aWePcbsItizIp+qVyfkfZiGgD+TbNxM12g7QhFAHIkx/mlYaocxPY/TmwPzTe+A==",
       "dev": true,
       "dependencies": {
-        "@algolia/client-common": "5.18.0",
-        "@algolia/requester-browser-xhr": "5.18.0",
-        "@algolia/requester-fetch": "5.18.0",
-        "@algolia/requester-node-http": "5.18.0"
+        "@algolia/client-common": "5.19.0",
+        "@algolia/requester-browser-xhr": "5.19.0",
+        "@algolia/requester-fetch": "5.19.0",
+        "@algolia/requester-node-http": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.18.0.tgz",
-      "integrity": "sha512-I2dc94Oiwic3SEbrRp8kvTZtYpJjGtg5y5XnqubgnA15AgX59YIY8frKsFG8SOH1n2rIhUClcuDkxYQNXJLg+w==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.19.0.tgz",
+      "integrity": "sha512-B9eoce/fk8NLboGje+pMr72pw+PV7c5Z01On477heTZ7jkxoZ4X92dobeGuEQop61cJ93Gaevd1of4mBr4hu2A==",
       "dev": true,
       "dependencies": {
-        "@algolia/client-common": "5.18.0",
-        "@algolia/requester-browser-xhr": "5.18.0",
-        "@algolia/requester-fetch": "5.18.0",
-        "@algolia/requester-node-http": "5.18.0"
+        "@algolia/client-common": "5.19.0",
+        "@algolia/requester-browser-xhr": "5.19.0",
+        "@algolia/requester-fetch": "5.19.0",
+        "@algolia/requester-node-http": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.18.0.tgz",
-      "integrity": "sha512-x6XKIQgKFTgK/bMasXhghoEjHhmgoP61pFPb9+TaUJ32aKOGc65b12usiGJ9A84yS73UDkXS452NjyP50Knh/g==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.19.0.tgz",
+      "integrity": "sha512-6fcP8d4S8XRDtVogrDvmSM6g5g6DndLc0pEm1GCKe9/ZkAzCmM3ZmW1wFYYPxdjMeifWy1vVEDMJK7sbE4W7MA==",
       "dev": true,
       "dependencies": {
-        "@algolia/client-common": "5.18.0",
-        "@algolia/requester-browser-xhr": "5.18.0",
-        "@algolia/requester-fetch": "5.18.0",
-        "@algolia/requester-node-http": "5.18.0"
+        "@algolia/client-common": "5.19.0",
+        "@algolia/requester-browser-xhr": "5.19.0",
+        "@algolia/requester-fetch": "5.19.0",
+        "@algolia/requester-node-http": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.18.0.tgz",
-      "integrity": "sha512-qI3LcFsVgtvpsBGR7aNSJYxhsR+Zl46+958ODzg8aCxIcdxiK7QEVLMJMZAR57jGqW0Lg/vrjtuLFDMfSE53qA==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.19.0.tgz",
+      "integrity": "sha512-Ctg3xXD/1VtcwmkulR5+cKGOMj4r0wC49Y/KZdGQcqpydKn+e86F6l3tb3utLJQVq4lpEJud6kdRykFgcNsp8Q==",
       "dev": true,
       "dependencies": {
-        "@algolia/client-common": "5.18.0",
-        "@algolia/requester-browser-xhr": "5.18.0",
-        "@algolia/requester-fetch": "5.18.0",
-        "@algolia/requester-node-http": "5.18.0"
+        "@algolia/client-common": "5.19.0",
+        "@algolia/requester-browser-xhr": "5.19.0",
+        "@algolia/requester-fetch": "5.19.0",
+        "@algolia/requester-node-http": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.18.0.tgz",
-      "integrity": "sha512-bGvJg7HnGGm+XWYMDruZXWgMDPVt4yCbBqq8DM6EoaMBK71SYC4WMfIdJaw+ABqttjBhe6aKNRkWf/bbvYOGyw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.19.0.tgz",
+      "integrity": "sha512-LO7w1MDV+ZLESwfPmXkp+KLeYeFrYEgtbCZG6buWjddhYraPQ9MuQWLhLLiaMlKxZ/sZvFTcZYuyI6Jx4WBhcg==",
       "dev": true,
       "dependencies": {
-        "@algolia/client-common": "5.18.0",
-        "@algolia/requester-browser-xhr": "5.18.0",
-        "@algolia/requester-fetch": "5.18.0",
-        "@algolia/requester-node-http": "5.18.0"
+        "@algolia/client-common": "5.19.0",
+        "@algolia/requester-browser-xhr": "5.19.0",
+        "@algolia/requester-fetch": "5.19.0",
+        "@algolia/requester-node-http": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.18.0.tgz",
-      "integrity": "sha512-lBssglINIeGIR+8KyzH05NAgAmn1BCrm5D2T6pMtr/8kbTHvvrm1Zvcltc5dKUQEFyyx3J5+MhNc7kfi8LdjVw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.19.0.tgz",
+      "integrity": "sha512-Mg4uoS0aIKeTpu6iv6O0Hj81s8UHagi5TLm9k2mLIib4vmMtX7WgIAHAcFIaqIZp5D6s5EVy1BaDOoZ7buuJHA==",
       "dev": true,
       "dependencies": {
-        "@algolia/client-common": "5.18.0",
-        "@algolia/requester-browser-xhr": "5.18.0",
-        "@algolia/requester-fetch": "5.18.0",
-        "@algolia/requester-node-http": "5.18.0"
+        "@algolia/client-common": "5.19.0",
+        "@algolia/requester-browser-xhr": "5.19.0",
+        "@algolia/requester-fetch": "5.19.0",
+        "@algolia/requester-node-http": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.18.0.tgz",
-      "integrity": "sha512-uSnkm0cdAuFwdMp4pGT5vHVQ84T6AYpTZ3I0b3k/M3wg4zXDhl3aCiY8NzokEyRLezz/kHLEEcgb/tTTobOYVw==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.19.0.tgz",
+      "integrity": "sha512-PbgrMTbUPlmwfJsxjFhal4XqZO2kpBNRjemLVTkUiti4w/+kzcYO4Hg5zaBgVqPwvFDNQ8JS4SS3TBBem88u+g==",
       "dev": true,
       "dependencies": {
-        "@algolia/client-common": "5.18.0",
-        "@algolia/requester-browser-xhr": "5.18.0",
-        "@algolia/requester-fetch": "5.18.0",
-        "@algolia/requester-node-http": "5.18.0"
+        "@algolia/client-common": "5.19.0",
+        "@algolia/requester-browser-xhr": "5.19.0",
+        "@algolia/requester-fetch": "5.19.0",
+        "@algolia/requester-node-http": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.18.0.tgz",
-      "integrity": "sha512-1XFjW0C3pV0dS/9zXbV44cKI+QM4ZIz9cpatXpsjRlq6SUCpLID3DZHsXyE6sTb8IhyPaUjk78GEJT8/3hviqg==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.19.0.tgz",
+      "integrity": "sha512-GfnhnQBT23mW/VMNs7m1qyEyZzhZz093aY2x8p0era96MMyNv8+FxGek5pjVX0b57tmSCZPf4EqNCpkGcGsmbw==",
       "dev": true,
       "dependencies": {
-        "@algolia/client-common": "5.18.0"
+        "@algolia/client-common": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.18.0.tgz",
-      "integrity": "sha512-0uodeNdAHz1YbzJh6C5xeQ4T6x5WGiUxUq3GOaT/R4njh5t78dq+Rb187elr7KtnjUmETVVuCvmEYaThfTHzNg==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.19.0.tgz",
+      "integrity": "sha512-oyTt8ZJ4T4fYvW5avAnuEc6Laedcme9fAFryMD9ndUTIUe/P0kn3BuGcCLFjN3FDmdrETHSFkgPPf1hGy3sLCw==",
       "dev": true,
       "dependencies": {
-        "@algolia/client-common": "5.18.0"
+        "@algolia/client-common": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.18.0.tgz",
-      "integrity": "sha512-tZCqDrqJ2YE2I5ukCQrYN8oiF6u3JIdCxrtKq+eniuLkjkO78TKRnXrVcKZTmfFJyyDK8q47SfDcHzAA3nHi6w==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.19.0.tgz",
+      "integrity": "sha512-p6t8ue0XZNjcRiqNkb5QAM0qQRAKsCiebZ6n9JjWA+p8fWf8BvnhO55y2fO28g3GW0Imj7PrAuyBuxq8aDVQwQ==",
       "dev": true,
       "dependencies": {
-        "@algolia/client-common": "5.18.0"
+        "@algolia/client-common": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -321,9 +321,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.3.tgz",
-      "integrity": "sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.5.tgz",
+      "integrity": "sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -369,13 +369,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
-      "integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
+      "integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
       "dev": true,
       "dependencies": {
-        "@babel/parser": "^7.26.3",
-        "@babel/types": "^7.26.3",
+        "@babel/parser": "^7.26.5",
+        "@babel/types": "^7.26.5",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -385,12 +385,12 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
-      "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz",
+      "integrity": "sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.25.9",
+        "@babel/compat-data": "^7.26.5",
         "@babel/helper-validator-option": "^7.25.9",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
@@ -449,9 +449,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
-      "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+      "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -498,12 +498,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
-      "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.5.tgz",
+      "integrity": "sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.26.3"
+        "@babel/types": "^7.26.5"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -568,16 +568,16 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.26.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
-      "integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.5.tgz",
+      "integrity": "sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.3",
-        "@babel/parser": "^7.26.3",
+        "@babel/generator": "^7.26.5",
+        "@babel/parser": "^7.26.5",
         "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.3",
+        "@babel/types": "^7.26.5",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -586,9 +586,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
-      "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.5.tgz",
+      "integrity": "sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
@@ -1094,9 +1094,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.1.tgz",
-      "integrity": "sha512-GuUdqkyyzQI5RMIWkHhvTWLCyLo1jNK3vzkSyaExH5kHPDHcuL2VOpHjmMY+y3+NC69qAKToBqldTBgYeLSr9Q==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.10.0.tgz",
+      "integrity": "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
@@ -1202,11 +1202,12 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.4.tgz",
-      "integrity": "sha512-zSkKow6H5Kdm0ZUQUB2kV5JIXqoG0+uH5YADhaEHswm664N9Db8dXSi0nMJpacpMf+MyyglF1vnZohpEg5yUtg==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.5.tgz",
+      "integrity": "sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==",
       "dev": true,
       "dependencies": {
+        "@eslint/core": "^0.10.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -1214,20 +1215,20 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
-      "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.8"
+        "@floating-ui/utils": "^0.2.9"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.12",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.12.tgz",
-      "integrity": "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==",
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
       "dependencies": {
         "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.8"
+        "@floating-ui/utils": "^0.2.9"
       }
     },
     "node_modules/@floating-ui/react": {
@@ -1257,9 +1258,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
-      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
     },
     "node_modules/@headlessui/react": {
       "version": "1.7.19",
@@ -1395,9 +1396,9 @@
       }
     },
     "node_modules/@iconify-json/simple-icons": {
-      "version": "1.2.18",
-      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.18.tgz",
-      "integrity": "sha512-ae4ig7fxNXME1wl5og7Ocp82TM4jyz6IsOyI8GrteSbvHR9gaPu2Z01Amn5V/xo1Y7A7/+EH/3Ovpy2az/gYbg==",
+      "version": "1.2.20",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.20.tgz",
+      "integrity": "sha512-WlQ95zrdxxizrFt2HtkfYjyWatLfE8Z7BKOkew9quG5S5AKYVxF1PkTtOs8LDWShce1DpvxKWQne4W5DQyEGZg==",
       "dev": true,
       "dependencies": {
         "@iconify/types": "*"
@@ -1760,27 +1761,27 @@
       }
     },
     "node_modules/@mantine/core": {
-      "version": "7.15.2",
-      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-7.15.2.tgz",
-      "integrity": "sha512-640ns0L/HZAXYjz3+FRffr8UNcH1fU7ENUVxKLzqNA311Dcx0qS3byVKTY/IVJYln6AkjoEfIJMiixT9fCZBiQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-7.16.0.tgz",
+      "integrity": "sha512-lYYwa4Itz77uC8zQzdiKiKdz9Q01NBOYPZsotIKsP/Zqij0qhpsVxoJ8MK3P8IqFyLfThTMmR4sT1qlGfLTA9Q==",
       "dependencies": {
         "@floating-ui/react": "^0.26.28",
         "clsx": "^2.1.1",
-        "react-number-format": "^5.4.2",
-        "react-remove-scroll": "^2.6.0",
+        "react-number-format": "^5.4.3",
+        "react-remove-scroll": "^2.6.2",
         "react-textarea-autosize": "8.5.6",
         "type-fest": "^4.27.0"
       },
       "peerDependencies": {
-        "@mantine/hooks": "7.15.2",
+        "@mantine/hooks": "7.16.0",
         "react": "^18.x || ^19.x",
         "react-dom": "^18.x || ^19.x"
       }
     },
     "node_modules/@mantine/hooks": {
-      "version": "7.15.2",
-      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-7.15.2.tgz",
-      "integrity": "sha512-p8dsW0fdJxzYhULbm1noFYRHuBvJHleYviC0BlwbkVySC8AsvFI8AmC3sMssWV3dQ3yQ/SidYo9U+K/czpDpZw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-7.16.0.tgz",
+      "integrity": "sha512-8KxrhckesbrV6tyOndm6fJ+jSKA4KX/67ppDFlfYMMbV6Yh+s0zRO4KLi2uCtl6tgckQd2/zDzX3kQk+VYKqDA==",
       "peerDependencies": {
         "react": "^18.x || ^19.x"
       }
@@ -2723,9 +2724,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.29.1.tgz",
-      "integrity": "sha512-ssKhA8RNltTZLpG6/QNkCSge+7mBQGUqJRisZ2MDQcEGaK93QESEgWK2iOpIDZ7k9zPVkG5AS3ksvD5ZWxmItw==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.30.1.tgz",
+      "integrity": "sha512-pSWY+EVt3rJ9fQ3IqlrEUtXh3cGqGtPDH1FQlNZehO2yYxCHEX1SPsz1M//NXwYfbTlcKr9WObLnJX9FsS9K1Q==",
       "cpu": [
         "arm"
       ],
@@ -2736,9 +2737,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.29.1.tgz",
-      "integrity": "sha512-CaRfrV0cd+NIIcVVN/jx+hVLN+VRqnuzLRmfmlzpOzB87ajixsN/+9L5xNmkaUUvEbI5BmIKS+XTwXsHEb65Ew==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.30.1.tgz",
+      "integrity": "sha512-/NA2qXxE3D/BRjOJM8wQblmArQq1YoBVJjrjoTSBS09jgUisq7bqxNHJ8kjCHeV21W/9WDGwJEWSN0KQ2mtD/w==",
       "cpu": [
         "arm64"
       ],
@@ -2749,9 +2750,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.29.1.tgz",
-      "integrity": "sha512-2ORr7T31Y0Mnk6qNuwtyNmy14MunTAMx06VAPI6/Ju52W10zk1i7i5U3vlDRWjhOI5quBcrvhkCHyF76bI7kEw==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.30.1.tgz",
+      "integrity": "sha512-r7FQIXD7gB0WJ5mokTUgUWPl0eYIH0wnxqeSAhuIwvnnpjdVB8cRRClyKLQr7lgzjctkbp5KmswWszlwYln03Q==",
       "cpu": [
         "arm64"
       ],
@@ -2762,9 +2763,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.29.1.tgz",
-      "integrity": "sha512-j/Ej1oanzPjmN0tirRd5K2/nncAhS9W6ICzgxV+9Y5ZsP0hiGhHJXZ2JQ53iSSjj8m6cRY6oB1GMzNn2EUt6Ng==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.30.1.tgz",
+      "integrity": "sha512-x78BavIwSH6sqfP2xeI1hd1GpHL8J4W2BXcVM/5KYKoAD3nNsfitQhvWSw+TFtQTLZ9OmlF+FEInEHyubut2OA==",
       "cpu": [
         "x64"
       ],
@@ -2775,9 +2776,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.29.1.tgz",
-      "integrity": "sha512-91C//G6Dm/cv724tpt7nTyP+JdN12iqeXGFM1SqnljCmi5yTXriH7B1r8AD9dAZByHpKAumqP1Qy2vVNIdLZqw==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.30.1.tgz",
+      "integrity": "sha512-HYTlUAjbO1z8ywxsDFWADfTRfTIIy/oUlfIDmlHYmjUP2QRDTzBuWXc9O4CXM+bo9qfiCclmHk1x4ogBjOUpUQ==",
       "cpu": [
         "arm64"
       ],
@@ -2788,9 +2789,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.29.1.tgz",
-      "integrity": "sha512-hEioiEQ9Dec2nIRoeHUP6hr1PSkXzQaCUyqBDQ9I9ik4gCXQZjJMIVzoNLBRGet+hIUb3CISMh9KXuCcWVW/8w==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.30.1.tgz",
+      "integrity": "sha512-1MEdGqogQLccphhX5myCJqeGNYTNcmTyaic9S7CG3JhwuIByJ7J05vGbZxsizQthP1xpVx7kd3o31eOogfEirw==",
       "cpu": [
         "x64"
       ],
@@ -2801,9 +2802,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.29.1.tgz",
-      "integrity": "sha512-Py5vFd5HWYN9zxBv3WMrLAXY3yYJ6Q/aVERoeUFwiDGiMOWsMs7FokXihSOaT/PMWUty/Pj60XDQndK3eAfE6A==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.30.1.tgz",
+      "integrity": "sha512-PaMRNBSqCx7K3Wc9QZkFx5+CX27WFpAMxJNiYGAXfmMIKC7jstlr32UhTgK6T07OtqR+wYlWm9IxzennjnvdJg==",
       "cpu": [
         "arm"
       ],
@@ -2814,9 +2815,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.29.1.tgz",
-      "integrity": "sha512-RiWpGgbayf7LUcuSNIbahr0ys2YnEERD4gYdISA06wa0i8RALrnzflh9Wxii7zQJEB2/Eh74dX4y/sHKLWp5uQ==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.30.1.tgz",
+      "integrity": "sha512-B8Rcyj9AV7ZlEFqvB5BubG5iO6ANDsRKlhIxySXcF1axXYUyqwBok+XZPgIYGBgs7LDXfWfifxhw0Ik57T0Yug==",
       "cpu": [
         "arm"
       ],
@@ -2827,9 +2828,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.29.1.tgz",
-      "integrity": "sha512-Z80O+taYxTQITWMjm/YqNoe9d10OX6kDh8X5/rFCMuPqsKsSyDilvfg+vd3iXIqtfmp+cnfL1UrYirkaF8SBZA==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.30.1.tgz",
+      "integrity": "sha512-hqVyueGxAj3cBKrAI4aFHLV+h0Lv5VgWZs9CUGqr1z0fZtlADVV1YPOij6AhcK5An33EXaxnDLmJdQikcn5NEw==",
       "cpu": [
         "arm64"
       ],
@@ -2840,9 +2841,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.29.1.tgz",
-      "integrity": "sha512-fOHRtF9gahwJk3QVp01a/GqS4hBEZCV1oKglVVq13kcK3NeVlS4BwIFzOHDbmKzt3i0OuHG4zfRP0YoG5OF/rA==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.30.1.tgz",
+      "integrity": "sha512-i4Ab2vnvS1AE1PyOIGp2kXni69gU2DAUVt6FSXeIqUCPIR3ZlheMW3oP2JkukDfu3PsexYRbOiJrY+yVNSk9oA==",
       "cpu": [
         "arm64"
       ],
@@ -2853,9 +2854,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.29.1.tgz",
-      "integrity": "sha512-5a7q3tnlbcg0OodyxcAdrrCxFi0DgXJSoOuidFUzHZ2GixZXQs6Tc3CHmlvqKAmOs5eRde+JJxeIf9DonkmYkw==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.30.1.tgz",
+      "integrity": "sha512-fARcF5g296snX0oLGkVxPmysetwUk2zmHcca+e9ObOovBR++9ZPOhqFUM61UUZ2EYpXVPN1redgqVoBB34nTpQ==",
       "cpu": [
         "loong64"
       ],
@@ -2866,9 +2867,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.29.1.tgz",
-      "integrity": "sha512-9b4Mg5Yfz6mRnlSPIdROcfw1BU22FQxmfjlp/CShWwO3LilKQuMISMTtAu/bxmmrE6A902W2cZJuzx8+gJ8e9w==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.30.1.tgz",
+      "integrity": "sha512-GLrZraoO3wVT4uFXh67ElpwQY0DIygxdv0BNW9Hkm3X34wu+BkqrDrkcsIapAY+N2ATEbvak0XQ9gxZtCIA5Rw==",
       "cpu": [
         "ppc64"
       ],
@@ -2879,9 +2880,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.29.1.tgz",
-      "integrity": "sha512-G5pn0NChlbRM8OJWpJFMX4/i8OEU538uiSv0P6roZcbpe/WfhEO+AT8SHVKfp8qhDQzaz7Q+1/ixMy7hBRidnQ==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.30.1.tgz",
+      "integrity": "sha512-0WKLaAUUHKBtll0wvOmh6yh3S0wSU9+yas923JIChfxOaaBarmb/lBKPF0w/+jTVozFnOXJeRGZ8NvOxvk/jcw==",
       "cpu": [
         "riscv64"
       ],
@@ -2892,9 +2893,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.29.1.tgz",
-      "integrity": "sha512-WM9lIkNdkhVwiArmLxFXpWndFGuOka4oJOZh8EP3Vb8q5lzdSCBuhjavJsw68Q9AKDGeOOIHYzYm4ZFvmWez5g==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.30.1.tgz",
+      "integrity": "sha512-GWFs97Ruxo5Bt+cvVTQkOJ6TIx0xJDD/bMAOXWJg8TCSTEK8RnFeOeiFTxKniTc4vMIaWvCplMAFBt9miGxgkA==",
       "cpu": [
         "s390x"
       ],
@@ -2905,9 +2906,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.29.1.tgz",
-      "integrity": "sha512-87xYCwb0cPGZFoGiErT1eDcssByaLX4fc0z2nRM6eMtV9njAfEE6OW3UniAoDhX4Iq5xQVpE6qO9aJbCFumKYQ==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.30.1.tgz",
+      "integrity": "sha512-UtgGb7QGgXDIO+tqqJ5oZRGHsDLO8SlpE4MhqpY9Llpzi5rJMvrK6ZGhsRCST2abZdBqIBeXW6WPD5fGK5SDwg==",
       "cpu": [
         "x64"
       ],
@@ -2918,9 +2919,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.29.1.tgz",
-      "integrity": "sha512-xufkSNppNOdVRCEC4WKvlR1FBDyqCSCpQeMMgv9ZyXqqtKBfkw1yfGMTUTs9Qsl6WQbJnsGboWCp7pJGkeMhKA==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.30.1.tgz",
+      "integrity": "sha512-V9U8Ey2UqmQsBT+xTOeMzPzwDzyXmnAoO4edZhL7INkwQcaW1Ckv3WJX3qrrp/VHaDkEWIBWhRwP47r8cdrOow==",
       "cpu": [
         "x64"
       ],
@@ -2931,9 +2932,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.29.1.tgz",
-      "integrity": "sha512-F2OiJ42m77lSkizZQLuC+jiZ2cgueWQL5YC9tjo3AgaEw+KJmVxHGSyQfDUoYR9cci0lAywv2Clmckzulcq6ig==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.30.1.tgz",
+      "integrity": "sha512-WabtHWiPaFF47W3PkHnjbmWawnX/aE57K47ZDT1BXTS5GgrBUEpvOzq0FI0V/UYzQJgdb8XlhVNH8/fwV8xDjw==",
       "cpu": [
         "arm64"
       ],
@@ -2944,9 +2945,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.29.1.tgz",
-      "integrity": "sha512-rYRe5S0FcjlOBZQHgbTKNrqxCBUmgDJem/VQTCcTnA2KCabYSWQDrytOzX7avb79cAAweNmMUb/Zw18RNd4mng==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.30.1.tgz",
+      "integrity": "sha512-pxHAU+Zv39hLUTdQQHUVHf4P+0C47y/ZloorHpzs2SXMRqeAWmGghzAhfOlzFHHwjvgokdFAhC4V+6kC1lRRfw==",
       "cpu": [
         "ia32"
       ],
@@ -2957,9 +2958,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.29.1.tgz",
-      "integrity": "sha512-+10CMg9vt1MoHj6x1pxyjPSMjHTIlqs8/tBztXvPAx24SKs9jwVnKqHJumlH/IzhaPUaj3T6T6wfZr8okdXaIg==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.30.1.tgz",
+      "integrity": "sha512-D6qjsXGcvhTjv0kI4fU8tUuBDF/Ueee4SVX79VfNDXZa64TfCW1Slkb6Z7O1p7vflqZjcmOVdZlqf8gvJxc6og==",
       "cpu": [
         "x64"
       ],
@@ -2970,14 +2971,14 @@
       ]
     },
     "node_modules/@shikijs/core": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.26.1.tgz",
-      "integrity": "sha512-yeo7sG+WZQblKPclUOKRPwkv1PyoHYkJ4gP9DzhFJbTdueKR7wYTI1vfF/bFi1NTgc545yG/DzvVhZgueVOXMA==",
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.27.2.tgz",
+      "integrity": "sha512-ns1dokDr0KE1lQ9mWd4rqaBkhSApk0qGCK1+lOqwnkQSkVZ08UGqXj1Ef8dAcTMZNFkN6PSNjkL5TYNX7pyPbQ==",
       "dev": true,
       "dependencies": {
-        "@shikijs/engine-javascript": "1.26.1",
-        "@shikijs/engine-oniguruma": "1.26.1",
-        "@shikijs/types": "1.26.1",
+        "@shikijs/engine-javascript": "1.27.2",
+        "@shikijs/engine-oniguruma": "1.27.2",
+        "@shikijs/types": "1.27.2",
         "@shikijs/vscode-textmate": "^10.0.1",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.4"
@@ -2993,57 +2994,57 @@
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.26.1.tgz",
-      "integrity": "sha512-CRhA0b8CaSLxS0E9A4Bzcb3LKBNpykfo9F85ozlNyArxjo2NkijtiwrJZ6eHa+NT5I9Kox2IXVdjUsP4dilsmw==",
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.27.2.tgz",
+      "integrity": "sha512-0JB7U5vJc16NShBdxv9hSSJYSKX79+32O7F4oXIxJLdYfomyFvx4B982ackUI9ftO9T3WwagkiiD3nOxOOLiGA==",
       "dev": true,
       "dependencies": {
-        "@shikijs/types": "1.26.1",
+        "@shikijs/types": "1.27.2",
         "@shikijs/vscode-textmate": "^10.0.1",
-        "oniguruma-to-es": "0.10.0"
+        "oniguruma-to-es": "^2.0.0"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.26.1.tgz",
-      "integrity": "sha512-F5XuxN1HljLuvfXv7d+mlTkV7XukC1cawdtOo+7pKgPD83CAB1Sf8uHqP3PK0u7njFH0ZhoXE1r+0JzEgAQ+kg==",
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.27.2.tgz",
+      "integrity": "sha512-FZYKD1KN7srvpkz4lbGLOYWlyDU4Rd+2RtuKfABTkafAPOFr+J6umfIwY/TzOQqfNtWjL7SAwPAO0dcOraRLaQ==",
       "dev": true,
       "dependencies": {
-        "@shikijs/types": "1.26.1",
+        "@shikijs/types": "1.27.2",
         "@shikijs/vscode-textmate": "^10.0.1"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-1.26.1.tgz",
-      "integrity": "sha512-oz/TQiIqZejEIZbGtn68hbJijAOTtYH4TMMSWkWYozwqdpKR3EXgILneQy26WItmJjp3xVspHdiUxUCws4gtuw==",
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-1.27.2.tgz",
+      "integrity": "sha512-MSrknKL0DbeXvhtSigMLIzjPOOQfvK7fsbcRv2NUUB0EvuTTomY8/U+lAkczYrXY2+dygKOapJKk8ScFYbtoNw==",
       "dev": true,
       "dependencies": {
-        "@shikijs/types": "1.26.1"
+        "@shikijs/types": "1.27.2"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-1.26.1.tgz",
-      "integrity": "sha512-JDxVn+z+wgLCiUhBGx2OQrLCkKZQGzNH3nAxFir4PjUcYiyD8Jdms9izyxIogYmSwmoPTatFTdzyrRKbKlSfPA==",
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-1.27.2.tgz",
+      "integrity": "sha512-Yw/uV7EijjWavIIZLoWneTAohcbBqEKj6XMX1bfMqO3llqTKsyXukPp1evf8qPqzUHY7ibauqEaQchhfi857mg==",
       "dev": true,
       "dependencies": {
-        "@shikijs/types": "1.26.1"
+        "@shikijs/types": "1.27.2"
       }
     },
     "node_modules/@shikijs/transformers": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.26.1.tgz",
-      "integrity": "sha512-IRLJEP7YxkRMsHo367+7qDlpWjsUu6O79pdlUlkcbF1A5TrF1Ln0FBNrgHA/i9p+IKXiiKNATURa6WXh3iq7Uw==",
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.27.2.tgz",
+      "integrity": "sha512-BJFeXP9/zlYidJocv2ShkOvXI22fepS2oK/vItfCbCcuJ0783eWgEn6/mMrXmk+p+Twu49ntDVQe665uy6RPWw==",
       "dev": true,
       "dependencies": {
-        "shiki": "1.26.1"
+        "shiki": "1.27.2"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.26.1.tgz",
-      "integrity": "sha512-d4B00TKKAMaHuFYgRf3L0gwtvqpW4hVdVwKcZYbBfAAQXspgkbWqnFfuFl3MDH6gLbsubOcr+prcnsqah3ny7Q==",
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.27.2.tgz",
+      "integrity": "sha512-DM9OWUyjmdYdnKDpaGB/GEn9XkToyK1tqxuqbmc5PV+5K8WjjwfygL3+cIvbkSw2v1ySwHDgqATq/+98pJ4Kyg==",
       "dev": true,
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.1",
@@ -3066,9 +3067,9 @@
       "dev": true
     },
     "node_modules/@tailwindcss/typography": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.15.tgz",
-      "integrity": "sha512-AqhlCXl+8grUz8uqExv5OTtgpjuVIwFTSXTrh8y9/pw6q2ek7fJ+Y8ZEVw7EB2DCcuCOtEjf9w3+J3rzts01uA==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
+      "integrity": "sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==",
       "dev": true,
       "dependencies": {
         "lodash.castarray": "^4.4.0",
@@ -3077,7 +3078,7 @@
         "postcss-selector-parser": "6.0.10"
       },
       "peerDependencies": {
-        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20"
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
       }
     },
     "node_modules/@tanstack/react-virtual": {
@@ -3229,15 +3230,15 @@
       "dev": true
     },
     "node_modules/@types/ms": {
-      "version": "0.7.34",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
-      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.17.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.11.tgz",
-      "integrity": "sha512-Ept5glCK35R8yeyIeYlRIZtX6SLRyqMhOFTgj5SOkMpLTdw3SEHI9fHx60xaUZ+V1aJxQJODE+7/j5ocZydYTg==",
+      "version": "20.17.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.14.tgz",
+      "integrity": "sha512-w6qdYetNL5KRBiSClK/KWai+2IMEJuAj+EujKCumalFOwXtvOXaEan9AuwcRID2IcOIAWSIfR495hBtgKlx2zg==",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -3579,21 +3580,21 @@
       }
     },
     "node_modules/@vue/devtools-api": {
-      "version": "7.6.8",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.6.8.tgz",
-      "integrity": "sha512-ma6dY/sZR36zALVsV1W7eC57c6IJPXsy8SNgZn1PLVWU4z4dPn5TIBmnF4stmdJ4sQcixqKaQ8pwjbMPzEZwiA==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.0.tgz",
+      "integrity": "sha512-bHEv6kT85BHtyGgDhE07bAUMAy7zpv6nnR004nSTd0wWMrAOtcrYoXO5iyr20Hkf5jR8obQOfS3byW+I3l2CCA==",
       "dev": true,
       "dependencies": {
-        "@vue/devtools-kit": "^7.6.8"
+        "@vue/devtools-kit": "^7.7.0"
       }
     },
     "node_modules/@vue/devtools-kit": {
-      "version": "7.6.8",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.6.8.tgz",
-      "integrity": "sha512-JhJ8M3sPU+v0P2iZBF2DkdmR9L0dnT5RXJabJqX6o8KtFs3tebdvfoXV2Dm3BFuqeECuMJIfF1aCzSt+WQ4wrw==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.0.tgz",
+      "integrity": "sha512-5cvZ+6SA88zKC8XiuxUfqpdTwVjJbvYnQZY5NReh7qlSGPvVDjjzyEtW+gdzLXNSd8tStgOjAdMCpvDQamUXtA==",
       "dev": true,
       "dependencies": {
-        "@vue/devtools-shared": "^7.6.8",
+        "@vue/devtools-shared": "^7.7.0",
         "birpc": "^0.2.19",
         "hookable": "^5.5.3",
         "mitt": "^3.0.1",
@@ -3603,9 +3604,9 @@
       }
     },
     "node_modules/@vue/devtools-shared": {
-      "version": "7.6.8",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.6.8.tgz",
-      "integrity": "sha512-9MBPO5Z3X1nYGFqTJyohl6Gmf/J7UNN1oicHdyzBVZP4jnhZ4c20MgtaHDIzWmHDHCMYVS5bwKxT3jxh7gOOKA==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.0.tgz",
+      "integrity": "sha512-jtlQY26R5thQxW9YQTpXbI0HoK0Wf9Rd4ekidOkRvSy7ChfK0kIU6vvcBtjj87/EcpeOSK49fZAicaFNJcoTcQ==",
       "dev": true,
       "dependencies": {
         "rfdc": "^1.4.1"
@@ -3896,9 +3897,9 @@
       }
     },
     "node_modules/@yext/pages-components": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@yext/pages-components/-/pages-components-1.0.4.tgz",
-      "integrity": "sha512-IrmKRPjNZvBryKN/lTtnfCD3QXsSlzrtEYhzPhw0xG0U++vRldH9D4LA3RRDw63KPTnqhtwjcYGCi9UOPuLF0g==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@yext/pages-components/-/pages-components-1.0.5.tgz",
+      "integrity": "sha512-R9xnHkTQuXlZPut0mJqMiKUhyDChzS9hcpL9XlPl7hZNQ96li0ECGuoBFJ2+c6s9WVeVmHvKFScFZDqvgMPtQA==",
       "dev": true,
       "dependencies": {
         "@lexical/code": "^0.12.5",
@@ -3938,8 +3939,8 @@
     },
     "node_modules/@yext/visual-editor": {
       "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@yext/visual-editor/-/visual-editor-0.0.22.tgz",
-      "integrity": "sha512-cU/5T7qSjQnhtOyGox2QS25mWv/uDWqSwMY/+RldcMYmkpKcyoSFr4vM8zehjl5r8FjLIPGJhkQNsM3ZrG07fw==",
+      "resolved": "https://github.com/jwartofsky-yext/publicAssets/raw/refs/heads/main/VE_LocalDevMode.tgz",
+      "integrity": "sha512-ZDXU3t6tG0fwansB6v5zNFlhLN35bjoAoWovv1fdU1VxypsmwyeMA8F42YtIEGu/GKOZ/Fhe3iKXxLJ4y3EG1g==",
       "dev": true,
       "dependencies": {
         "@measured/puck": "0.17.1",
@@ -3997,9 +3998,9 @@
       }
     },
     "node_modules/@yext/visual-editor/node_modules/@eslint/js": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.17.0.tgz",
-      "integrity": "sha512-Sxc4hqcs1kTu0iID3kcZDW3JHq2a77HO9P8CP6YEA/FpH3Ll8UXE2r/86Rz9YJLKme39S9vU5OWNjC6Xl0Cr3w==",
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.18.0.tgz",
+      "integrity": "sha512-fK6L7rxcq6/z+AaQMtiFTkvbHkBLNlwyRxHpKawP0x3u9+NC6MQTnFW+AdpwC6gfHTW0051cokQgtTN2FqlxQA==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4047,18 +4048,18 @@
       }
     },
     "node_modules/@yext/visual-editor/node_modules/eslint": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.17.0.tgz",
-      "integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.18.0.tgz",
+      "integrity": "sha512-+waTfRWQlSbpt3KWE+CjrPPYnbq9kfZIYUqapc0uBXyjTp8aYXZDsUH16m39Ryq3NjAVP4tjuF7KaukeqoCoaA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
         "@eslint/config-array": "^0.19.0",
-        "@eslint/core": "^0.9.0",
+        "@eslint/core": "^0.10.0",
         "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.17.0",
-        "@eslint/plugin-kit": "^0.2.3",
+        "@eslint/js": "9.18.0",
+        "@eslint/plugin-kit": "^0.2.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.1",
@@ -4259,24 +4260,24 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.18.0.tgz",
-      "integrity": "sha512-/tfpK2A4FpS0o+S78o3YSdlqXr0MavJIDlFK3XZrlXLy7vaRXJvW5jYg3v5e/wCaF8y0IpMjkYLhoV6QqfpOgw==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.19.0.tgz",
+      "integrity": "sha512-zrLtGhC63z3sVLDDKGW+SlCRN9eJHFTgdEmoAOpsVh6wgGL1GgTTDou7tpCBjevzgIvi3AIyDAQO3Xjbg5eqZg==",
       "dev": true,
       "dependencies": {
-        "@algolia/client-abtesting": "5.18.0",
-        "@algolia/client-analytics": "5.18.0",
-        "@algolia/client-common": "5.18.0",
-        "@algolia/client-insights": "5.18.0",
-        "@algolia/client-personalization": "5.18.0",
-        "@algolia/client-query-suggestions": "5.18.0",
-        "@algolia/client-search": "5.18.0",
-        "@algolia/ingestion": "1.18.0",
-        "@algolia/monitoring": "1.18.0",
-        "@algolia/recommend": "5.18.0",
-        "@algolia/requester-browser-xhr": "5.18.0",
-        "@algolia/requester-fetch": "5.18.0",
-        "@algolia/requester-node-http": "5.18.0"
+        "@algolia/client-abtesting": "5.19.0",
+        "@algolia/client-analytics": "5.19.0",
+        "@algolia/client-common": "5.19.0",
+        "@algolia/client-insights": "5.19.0",
+        "@algolia/client-personalization": "5.19.0",
+        "@algolia/client-query-suggestions": "5.19.0",
+        "@algolia/client-search": "5.19.0",
+        "@algolia/ingestion": "1.19.0",
+        "@algolia/monitoring": "1.19.0",
+        "@algolia/recommend": "5.19.0",
+        "@algolia/requester-browser-xhr": "5.19.0",
+        "@algolia/requester-fetch": "5.19.0",
+        "@algolia/requester-node-http": "5.19.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -4865,9 +4866,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
-      "integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
       "dev": true,
       "funding": [
         {
@@ -5046,9 +5047,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001690",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
-      "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
+      "version": "1.0.30001692",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001692.tgz",
+      "integrity": "sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==",
       "dev": true,
       "funding": [
         {
@@ -5803,9 +5804,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.76",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
-      "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+      "version": "1.5.83",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.83.tgz",
+      "integrity": "sha512-LcUDPqSt+V0QmI47XLzZrz5OqILSMGsPFkDYus22rIbgorSvBYEFqq854ltTmUdHkY92FSdAAvsh4jWEULMdfQ==",
       "dev": true
     },
     "node_modules/elliptic": {
@@ -5969,9 +5970,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -6157,9 +6158,9 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.37.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.3.tgz",
-      "integrity": "sha512-DomWuTQPFYZwF/7c9W2fkKkStqZmBd3uugfqBYLdkZ3Hii23WzZuOLUskGxB8qkSKqftxEeGL1TB2kMhrce0jA==",
+      "version": "7.37.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.4.tgz",
+      "integrity": "sha512-BGP0jRmfYyvOyvMoRX/uoUeW+GqNj9y16bPQzqAHf3AYII/tDs+jMN0dBVkl88/OZwNGwrVFxE7riHsXVfy/LQ==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.8",
@@ -6514,15 +6515,15 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -6654,9 +6655,9 @@
       "dev": true
     },
     "node_modules/focus-trap": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.2.tgz",
-      "integrity": "sha512-9FhUxK1hVju2+AiQIDJ5Dd//9R2n2RAfJ0qfhF4IHGHgcoEUTMpbTeG/zbEuwaiYXfuAH6XE0/aCyxDdRM+W5w==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.4.tgz",
+      "integrity": "sha512-xx560wGBk7seZ6y933idtjJQc1l+ck+pI3sKvhKozdBV1dRZoKhkW5xoCaFv9tQiX5RH1xfSxjuNu6g+lmN/gw==",
       "dev": true,
       "dependencies": {
         "tabbable": "^6.2.0"
@@ -6718,9 +6719,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -9528,9 +9529,9 @@
       }
     },
     "node_modules/oniguruma-to-es": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-0.10.0.tgz",
-      "integrity": "sha512-zapyOUOCJxt+xhiNRPPMtfJkHGsZ98HHB9qJEkdT8BGytO/+kpe4m1Ngf0MzbzTmhacn11w9yGeDP6tzDhnCdg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.1.0.tgz",
+      "integrity": "sha512-Iq/949c5IueVC5gQR7OYXs0uHsDIePcgZFlVRIVGfQcWwbKG+nsyWfthswdytShlRdkZADY+bWSi+BRyUL81gA==",
       "dev": true,
       "dependencies": {
         "emoji-regex-xs": "^1.0.0",
@@ -9922,9 +9923,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
+      "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -9940,7 +9941,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.7",
+        "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -11060,9 +11061,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.29.1.tgz",
-      "integrity": "sha512-RaJ45M/kmJUzSWDs1Nnd5DdV4eerC98idtUOVr6FfKcgxqvjwHmxc5upLF9qZU9EpsVzzhleFahrT3shLuJzIw==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.30.1.tgz",
+      "integrity": "sha512-mlJ4glW020fPuLi7DkM/lN97mYEZGWeqBnrljzN0gs7GLctqX3lNWxKQ7Gl712UAX+6fog/L3jh4gb7R6aVi3w==",
       "dev": true,
       "dependencies": {
         "@types/estree": "1.0.6"
@@ -11075,25 +11076,25 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.29.1",
-        "@rollup/rollup-android-arm64": "4.29.1",
-        "@rollup/rollup-darwin-arm64": "4.29.1",
-        "@rollup/rollup-darwin-x64": "4.29.1",
-        "@rollup/rollup-freebsd-arm64": "4.29.1",
-        "@rollup/rollup-freebsd-x64": "4.29.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.29.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.29.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.29.1",
-        "@rollup/rollup-linux-arm64-musl": "4.29.1",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.29.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.29.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.29.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.29.1",
-        "@rollup/rollup-linux-x64-gnu": "4.29.1",
-        "@rollup/rollup-linux-x64-musl": "4.29.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.29.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.29.1",
-        "@rollup/rollup-win32-x64-msvc": "4.29.1",
+        "@rollup/rollup-android-arm-eabi": "4.30.1",
+        "@rollup/rollup-android-arm64": "4.30.1",
+        "@rollup/rollup-darwin-arm64": "4.30.1",
+        "@rollup/rollup-darwin-x64": "4.30.1",
+        "@rollup/rollup-freebsd-arm64": "4.30.1",
+        "@rollup/rollup-freebsd-x64": "4.30.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.30.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.30.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.30.1",
+        "@rollup/rollup-linux-arm64-musl": "4.30.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.30.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.30.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.30.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.30.1",
+        "@rollup/rollup-linux-x64-gnu": "4.30.1",
+        "@rollup/rollup-linux-x64-musl": "4.30.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.30.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.30.1",
+        "@rollup/rollup-win32-x64-msvc": "4.30.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -11402,17 +11403,17 @@
       }
     },
     "node_modules/shiki": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.26.1.tgz",
-      "integrity": "sha512-Gqg6DSTk3wYqaZ5OaYtzjcdxcBvX5kCy24yvRJEgjT5U+WHlmqCThLuBUx0juyxQBi+6ug53IGeuQS07DWwpcw==",
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.27.2.tgz",
+      "integrity": "sha512-QtA1C41oEVixKog+V8I3ia7jjGls7oCZ8Yul8vdHrVBga5uPoyTtMvFF4lMMXIyAZo5A5QbXq91bot2vA6Q+eQ==",
       "dev": true,
       "dependencies": {
-        "@shikijs/core": "1.26.1",
-        "@shikijs/engine-javascript": "1.26.1",
-        "@shikijs/engine-oniguruma": "1.26.1",
-        "@shikijs/langs": "1.26.1",
-        "@shikijs/themes": "1.26.1",
-        "@shikijs/types": "1.26.1",
+        "@shikijs/core": "1.27.2",
+        "@shikijs/engine-javascript": "1.27.2",
+        "@shikijs/engine-oniguruma": "1.27.2",
+        "@shikijs/langs": "1.27.2",
+        "@shikijs/themes": "1.27.2",
+        "@shikijs/types": "1.27.2",
         "@shikijs/vscode-textmate": "^10.0.1",
         "@types/hast": "^3.0.4"
       }
@@ -11525,9 +11526,9 @@
       }
     },
     "node_modules/sonner": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.1.tgz",
-      "integrity": "sha512-b6LHBfH32SoVasRFECrdY8p8s7hXPDn3OHUFbZZbiB1ctLS9Gdh6rpX2dVrpQA0kiL5jcRzDDldwwLkSKk3+QQ==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.2.tgz",
+      "integrity": "sha512-zMbseqjrOzQD1a93lxahm+qMGxWovdMxBlkTbbnZdNqVLt4j+amF9PQxUCL32WfztOFt9t9ADYkejAL3jF9iNA==",
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
         "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
@@ -12141,9 +12142,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.31.0.tgz",
-      "integrity": "sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.32.0.tgz",
+      "integrity": "sha512-rfgpoi08xagF3JSdtJlCwMq9DGNDE0IMh3Mkpc1wUypg9vPi786AiqeBBKcqvIkq42azsBM85N490fyZjeUftw==",
       "engines": {
         "node": ">=16"
       },
@@ -12239,9 +12240,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -12474,9 +12475,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
+      "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
       "dev": true,
       "funding": [
         {
@@ -12494,7 +12495,7 @@
       ],
       "dependencies": {
         "escalade": "^3.2.0",
-        "picocolors": "^1.1.0"
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -12810,9 +12811,6 @@
       "resolved": "https://registry.npmjs.org/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.17.0.tgz",
       "integrity": "sha512-iPmPn7376e5u6QvoTSJa16hf5Q0DFwHFXJk2uYpsNlmI3JdPms7hWyh55o+OysJ5jo9J5XPhLC9sMOYifwFd1w==",
       "dev": true,
-      "workspaces": [
-        "."
-      ],
       "dependencies": {
         "@rollup/plugin-inject": "^5.0.5",
         "buffer-polyfill": "npm:buffer@^6.0.3",
@@ -13547,13 +13545,13 @@
       }
     },
     "node_modules/yjs": {
-      "version": "13.6.21",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.21.tgz",
-      "integrity": "sha512-/fzzyeCAfr3Qwx1D71zvumm64x+Q5MEFel6EhWlA1IBFxWPb7tei4J2a8CJyjpYHfVrRij5q3RJTK9W2Iqjouw==",
+      "version": "13.6.23",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.23.tgz",
+      "integrity": "sha512-ExtnT5WIOVpkL56bhLeisG/N5c4fmzKn4k0ROVfJa5TY2QHbH7F0Wu2T5ZhR7ErsFWQEFafyrnSI8TPKVF9Few==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "lib0": "^0.2.98"
+        "lib0": "^0.2.99"
       },
       "engines": {
         "node": ">=16.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "@yext/pages": "1.2.0-beta.4",
     "@yext/pages-components": "^1.0.2",
-    "@yext/visual-editor": "0.0.22",
+    "@yext/visual-editor": "https://github.com/jwartofsky-yext/publicAssets/raw/refs/heads/main/VE_LocalDevMode.tgz",
     "autoprefixer": "^10.4.8",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-react": "^7.31.7",

--- a/src/dev.config.ts
+++ b/src/dev.config.ts
@@ -1,0 +1,9780 @@
+export const devTemplateStream = {
+  "stream": {
+    "accountId": "1000146856",
+    "id": "62564-jwartofskylocation7-stream-whvsu5uhnw",
+    "version": 1,
+    "destination": {
+      "topic": "cog-streams-documents"
+    },
+    "documentType": "DOCUMENT_TYPE_ENTITY",
+    "scope": {
+      "entityScope": {
+        "entityTypes": {
+          "ids": [
+            "location"
+          ]
+        },
+        "localization": {
+          "locales": [
+            "en"
+          ]
+        }
+      }
+    },
+    "expression": {
+      "fields": [
+        {
+          "name": "accessHours",
+          "fullObject": true
+        },
+        {
+          "name": "appleActionLinks",
+          "fullObject": true
+        },
+        {
+          "name": "appleBusinessDescription",
+          "fullObject": true
+        },
+        {
+          "name": "appleBusinessId",
+          "fullObject": true
+        },
+        {
+          "name": "appleCompanyId",
+          "fullObject": true
+        },
+        {
+          "name": "appleCoverPhoto",
+          "fullObject": true
+        },
+        {
+          "name": "bingParentLocation",
+          "fullObject": true
+        },
+        {
+          "name": "bingRelationshipType",
+          "fullObject": true
+        },
+        {
+          "name": "bingWebsiteOverride",
+          "fullObject": true
+        },
+        {
+          "name": "blackOwnedBusiness",
+          "fullObject": true
+        },
+        {
+          "name": "brunchHours",
+          "fullObject": true
+        },
+        {
+          "name": "covid19InformationUrl",
+          "fullObject": true
+        },
+        {
+          "name": "covidMessaging",
+          "fullObject": true
+        },
+        {
+          "name": "deliverListingsWithoutGeocode",
+          "fullObject": true
+        },
+        {
+          "name": "deliveryHours",
+          "fullObject": true
+        },
+        {
+          "name": "deliveryUrl",
+          "fullObject": true
+        },
+        {
+          "name": "dineInHours",
+          "fullObject": true
+        },
+        {
+          "name": "driveThroughHours",
+          "fullObject": true
+        },
+        {
+          "name": "facebookWebsiteOverride",
+          "fullObject": true
+        },
+        {
+          "name": "fullyVaccinatedStaff",
+          "fullObject": true
+        },
+        {
+          "name": "geomodifier",
+          "fullObject": true
+        },
+        {
+          "name": "happyHours",
+          "fullObject": true
+        },
+        {
+          "name": "holidayHoursConversationEnabled",
+          "fullObject": true
+        },
+        {
+          "name": "kitchenHours",
+          "fullObject": true
+        },
+        {
+          "name": "landingPageUrl",
+          "fullObject": true
+        },
+        {
+          "name": "linkedInUrl",
+          "fullObject": true
+        },
+        {
+          "name": "neighborhood",
+          "fullObject": true
+        },
+        {
+          "name": "nudgeEnabled",
+          "fullObject": true
+        },
+        {
+          "name": "onlineServiceHours",
+          "fullObject": true
+        },
+        {
+          "name": "phoneticName",
+          "fullObject": true
+        },
+        {
+          "name": "pickupAndDeliveryServices",
+          "fullObject": true
+        },
+        {
+          "name": "pickupHours",
+          "fullObject": true
+        },
+        {
+          "name": "primaryConversationContact",
+          "fullObject": true
+        },
+        {
+          "name": "proofOfVaccinationRequired",
+          "fullObject": true
+        },
+        {
+          "name": "reviewResponseConversationEnabled",
+          "fullObject": true
+        },
+        {
+          "name": "seniorHours",
+          "fullObject": true
+        },
+        {
+          "name": "slug",
+          "fullObject": true
+        },
+        {
+          "name": "takeoutHours",
+          "fullObject": true
+        },
+        {
+          "name": "inBound",
+          "fullObject": true
+        },
+        {
+          "name": "outBound",
+          "fullObject": true
+        },
+        {
+          "name": "what3WordsAddress",
+          "fullObject": true
+        },
+        {
+          "name": "yelpWebsiteOverride",
+          "fullObject": true
+        },
+        {
+          "name": "additionalHoursText",
+          "fullObject": true
+        },
+        {
+          "name": "address",
+          "fullObject": true
+        },
+        {
+          "name": "addressHidden",
+          "fullObject": true
+        },
+        {
+          "name": "alternatePhone",
+          "fullObject": true
+        },
+        {
+          "name": "androidAppUrl",
+          "fullObject": true
+        },
+        {
+          "name": "associations",
+          "fullObject": true
+        },
+        {
+          "name": "brands",
+          "fullObject": true
+        },
+        {
+          "name": "description",
+          "fullObject": true
+        },
+        {
+          "name": "hours",
+          "fullObject": true
+        },
+        {
+          "name": "logo",
+          "fullObject": true
+        },
+        {
+          "name": "name",
+          "fullObject": true
+        },
+        {
+          "name": "cityCoordinate",
+          "fullObject": true
+        },
+        {
+          "name": "closed",
+          "fullObject": true
+        },
+        {
+          "name": "c_callToAction",
+          "fullObject": true
+        },
+        {
+          "name": "c_deliveryPromo",
+          "fullObject": true
+        },
+        {
+          "name": "c_faqSection",
+          "fullObject": true
+        },
+        {
+          "name": "c_hero",
+          "fullObject": true
+        },
+        {
+          "name": "c_productSection",
+          "fullObject": true
+        },
+        {
+          "name": "displayCoordinate",
+          "fullObject": true
+        },
+        {
+          "name": "dropoffCoordinate",
+          "fullObject": true
+        },
+        {
+          "name": "bios",
+          "fullObject": true
+        },
+        {
+          "name": "menus",
+          "fullObject": true
+        },
+        {
+          "name": "productLists",
+          "fullObject": true
+        },
+        {
+          "name": "emails",
+          "fullObject": true
+        },
+        {
+          "name": "facebookPageUrl",
+          "fullObject": true
+        },
+        {
+          "name": "fax",
+          "fullObject": true
+        },
+        {
+          "name": "featuredMessage",
+          "fullObject": true
+        },
+        {
+          "name": "photoGallery",
+          "fullObject": true
+        },
+        {
+          "name": "geocodedCoordinate",
+          "fullObject": true
+        },
+        {
+          "name": "googleWebsiteOverride",
+          "fullObject": true
+        },
+        {
+          "name": "instagramHandle",
+          "fullObject": true
+        },
+        {
+          "name": "iosAppUrl",
+          "fullObject": true
+        },
+        {
+          "name": "isoRegionCode",
+          "fullObject": true
+        },
+        {
+          "name": "keywords",
+          "fullObject": true
+        },
+        {
+          "name": "labels",
+          "fullObject": true
+        },
+        {
+          "name": "languages",
+          "fullObject": true
+        },
+        {
+          "name": "localPhone",
+          "fullObject": true
+        },
+        {
+          "name": "mainPhone",
+          "fullObject": true
+        },
+        {
+          "name": "menuUrl",
+          "fullObject": true
+        },
+        {
+          "name": "mobilePhone",
+          "fullObject": true
+        },
+        {
+          "name": "orderUrl",
+          "fullObject": true
+        },
+        {
+          "name": "paymentOptions",
+          "fullObject": true
+        },
+        {
+          "name": "pickupCoordinate",
+          "fullObject": true
+        },
+        {
+          "name": "priceRange",
+          "fullObject": true
+        },
+        {
+          "name": "products",
+          "fullObject": true
+        },
+        {
+          "name": "reservationUrl",
+          "fullObject": true
+        },
+        {
+          "name": "routableCoordinate",
+          "fullObject": true
+        },
+        {
+          "name": "services",
+          "fullObject": true
+        },
+        {
+          "name": "specialities",
+          "fullObject": true
+        },
+        {
+          "name": "timezone",
+          "fullObject": true
+        },
+        {
+          "name": "tollFreePhone",
+          "fullObject": true
+        },
+        {
+          "name": "ttyPhone",
+          "fullObject": true
+        },
+        {
+          "name": "twitterHandle",
+          "fullObject": true
+        },
+        {
+          "name": "walkableCoordinate",
+          "fullObject": true
+        },
+        {
+          "name": "websiteUrl",
+          "fullObject": true
+        },
+        {
+          "name": "yearEstablished",
+          "fullObject": true
+        },
+        {
+          "name": "yextDisplayCoordinate",
+          "fullObject": true
+        },
+        {
+          "name": "yextDropoffCoordinate",
+          "fullObject": true
+        },
+        {
+          "name": "yextPickupCoordinate",
+          "fullObject": true
+        },
+        {
+          "name": "yextRoutableCoordinate",
+          "fullObject": true
+        },
+        {
+          "name": "yextWalkableCoordinate",
+          "fullObject": true
+        },
+        {
+          "name": "videos",
+          "fullObject": true
+        },
+        {
+          "name": "meta",
+          "children": {
+            "fields": [
+              {
+                "name": "locale",
+                "fullObject": true
+              },
+              {
+                "name": "entityType",
+                "fullObject": true
+              }
+            ]
+          }
+        },
+        {
+          "name": "id",
+          "fullObject": true
+        },
+        {
+          "name": "uid",
+          "fullObject": true
+        }
+      ]
+    },
+    "schema": {
+      "fields": [
+        {
+          "name": "accessHours",
+          "definition": {
+            "name": "accessHours",
+            "registryId": "entity.access_hours",
+            "typeRegistryId": "type.hours",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "monday",
+                "definition": {
+                  "name": "monday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "tuesday",
+                "definition": {
+                  "name": "tuesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "wednesday",
+                "definition": {
+                  "name": "wednesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "thursday",
+                "definition": {
+                  "name": "thursday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "friday",
+                "definition": {
+                  "name": "friday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "saturday",
+                "definition": {
+                  "name": "saturday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "sunday",
+                "definition": {
+                  "name": "sunday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "holidayHours",
+                "definition": {
+                  "name": "holidayHours",
+                  "typeRegistryId": "type.holiday_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  },
+                  "isList": true
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "date",
+                      "definition": {
+                        "name": "date",
+                        "typeRegistryId": "type.date",
+                        "type": {
+                          "stringType": "STRING_TYPE_DATE"
+                        }
+                      }
+                    },
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    },
+                    {
+                      "name": "isRegularHours",
+                      "definition": {
+                        "name": "isRegularHours",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "reopenDate",
+                "definition": {
+                  "name": "reopenDate",
+                  "typeRegistryId": "type.date",
+                  "type": {
+                    "stringType": "STRING_TYPE_DATE"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "appleActionLinks",
+          "definition": {
+            "name": "appleActionLinks",
+            "registryId": "entity.apple_action_links",
+            "typeRegistryId": "type.apple_cta",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            },
+            "isList": true
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "category",
+                "definition": {
+                  "name": "category",
+                  "typeRegistryId": "type.option",
+                  "type": {
+                    "stringType": "STRING_TYPE_OPTION"
+                  },
+                  "options": [
+                    {
+                      "textValue": "BOOK_TRAVEL",
+                      "displayName": "Book Travel"
+                    },
+                    {
+                      "textValue": "CHECK_IN",
+                      "displayName": "Check in"
+                    },
+                    {
+                      "textValue": "FEES_POLICIES",
+                      "displayName": "Fees Policies - Deprecated"
+                    },
+                    {
+                      "textValue": "FLIGHT_STATUS",
+                      "displayName": "Flight Status"
+                    },
+                    {
+                      "textValue": "TICKETS",
+                      "displayName": "Tickets"
+                    },
+                    {
+                      "textValue": "TICKETING",
+                      "displayName": "Ticketing - Deprecated"
+                    },
+                    {
+                      "textValue": "AMENITIES",
+                      "displayName": "Amenities"
+                    },
+                    {
+                      "textValue": "FRONT_DESK",
+                      "displayName": "Front Desk - Deprecated"
+                    },
+                    {
+                      "textValue": "PARKING",
+                      "displayName": "Parking"
+                    },
+                    {
+                      "textValue": "GIFT_CARD",
+                      "displayName": "Gift Card"
+                    },
+                    {
+                      "textValue": "WAITLIST",
+                      "displayName": "Waitlist"
+                    },
+                    {
+                      "textValue": "DELIVERY",
+                      "displayName": "Delivery (Restaurant)"
+                    },
+                    {
+                      "textValue": "ORDER",
+                      "displayName": "Order (Restaurant)"
+                    },
+                    {
+                      "textValue": "TAKEOUT",
+                      "displayName": "Takeout - Deprecated"
+                    },
+                    {
+                      "textValue": "PICKUP",
+                      "displayName": "Pickup (Restaurant)"
+                    },
+                    {
+                      "textValue": "RESERVE",
+                      "displayName": "Reserve (Restaurant)"
+                    },
+                    {
+                      "textValue": "MENU",
+                      "displayName": "Menu"
+                    },
+                    {
+                      "textValue": "APPOINTMENT",
+                      "displayName": "Appointment - Deprecated"
+                    },
+                    {
+                      "textValue": "PORTFOLIO",
+                      "displayName": "Portfolio - Deprecated"
+                    },
+                    {
+                      "textValue": "QUOTE",
+                      "displayName": "Quote"
+                    },
+                    {
+                      "textValue": "SERVICES",
+                      "displayName": "Services"
+                    },
+                    {
+                      "textValue": "STORE_ORDERS",
+                      "displayName": "Store Orders - Deprecated"
+                    },
+                    {
+                      "textValue": "STORE_SHOP",
+                      "displayName": "Store Shop - Deprecated"
+                    },
+                    {
+                      "textValue": "STORE_SUPPORT",
+                      "displayName": "Store Support - Deprecated"
+                    },
+                    {
+                      "textValue": "SCHEDULE",
+                      "displayName": "Schedule"
+                    },
+                    {
+                      "textValue": "SHOWTIMES",
+                      "displayName": "Showtimes"
+                    },
+                    {
+                      "textValue": "AVAILABILITY",
+                      "displayName": "Availability"
+                    },
+                    {
+                      "textValue": "PRICING",
+                      "displayName": "Pricing"
+                    },
+                    {
+                      "textValue": "ACTIVITIES",
+                      "displayName": "Activities"
+                    },
+                    {
+                      "textValue": "BOOK",
+                      "displayName": "Book"
+                    },
+                    {
+                      "textValue": "BOOK_(HOTEL)",
+                      "displayName": "Book (Hotel)"
+                    },
+                    {
+                      "textValue": "BOOK_(RIDE)",
+                      "displayName": "Book Ride"
+                    },
+                    {
+                      "textValue": "BOOK_(TOUR)",
+                      "displayName": "Book Tour"
+                    },
+                    {
+                      "textValue": "CAREERS",
+                      "displayName": "Careers"
+                    },
+                    {
+                      "textValue": "CHARGE",
+                      "displayName": "Charge"
+                    },
+                    {
+                      "textValue": "COUPONS",
+                      "displayName": "Coupons"
+                    },
+                    {
+                      "textValue": "DELIVERY_(RETAIL)",
+                      "displayName": "Delivery (Retail)"
+                    },
+                    {
+                      "textValue": "DONATE",
+                      "displayName": "Donate"
+                    },
+                    {
+                      "textValue": "EVENTS",
+                      "displayName": "Events"
+                    },
+                    {
+                      "textValue": "ORDER_(RETAIL)",
+                      "displayName": "Order (Retail)"
+                    },
+                    {
+                      "textValue": "OTHER_MENU",
+                      "displayName": "Other Menu - Deprecated"
+                    },
+                    {
+                      "textValue": "PICKUP_(RETAIL)",
+                      "displayName": "Pickup (Retail)"
+                    },
+                    {
+                      "textValue": "RESERVE_(PARKING)",
+                      "displayName": "Reserve (Parking)"
+                    },
+                    {
+                      "textValue": "SHOWS",
+                      "displayName": "Shows"
+                    },
+                    {
+                      "textValue": "SPORTS",
+                      "displayName": "Sports"
+                    },
+                    {
+                      "textValue": "SUPPORT",
+                      "displayName": "Support"
+                    },
+                    {
+                      "textValue": "TEE_TIME",
+                      "displayName": "Tee Time"
+                    },
+                    {
+                      "textValue": "GIFT_CARD_(RESTAURANT)",
+                      "displayName": "Gift Card (Restaurant) - Deprecated"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "appStoreUrl",
+                "definition": {
+                  "name": "appStoreUrl",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_URL"
+                  }
+                }
+              },
+              {
+                "name": "quickLinkUrl",
+                "definition": {
+                  "name": "quickLinkUrl",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_URL"
+                  }
+                }
+              },
+              {
+                "name": "appName",
+                "definition": {
+                  "name": "appName",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "appleBusinessDescription",
+          "definition": {
+            "name": "appleBusinessDescription",
+            "registryId": "entity.apple_business_description",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_MULTILINE"
+            }
+          }
+        },
+        {
+          "name": "appleBusinessId",
+          "definition": {
+            "name": "appleBusinessId",
+            "registryId": "entity.apple_business_id",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_ID"
+            }
+          }
+        },
+        {
+          "name": "appleCompanyId",
+          "definition": {
+            "name": "appleCompanyId",
+            "registryId": "entity.apple_company_id",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_ID"
+            }
+          }
+        },
+        {
+          "name": "appleCoverPhoto",
+          "definition": {
+            "name": "appleCoverPhoto",
+            "registryId": "entity.apple_cover_photo",
+            "typeRegistryId": "type.image",
+            "type": {
+              "objectType": "OBJECT_TYPE_IMAGE"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "url",
+                "definition": {
+                  "name": "url",
+                  "type": {
+                    "stringType": "STRING_TYPE_URL"
+                  }
+                }
+              },
+              {
+                "name": "alternateText",
+                "definition": {
+                  "name": "alternateText",
+                  "type": {
+                    "stringType": "STRING_TYPE_MULTILINE"
+                  }
+                }
+              },
+              {
+                "name": "width",
+                "definition": {
+                  "name": "width",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_INT"
+                  }
+                }
+              },
+              {
+                "name": "height",
+                "definition": {
+                  "name": "height",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_INT"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "bingParentLocation",
+          "definition": {
+            "name": "bingParentLocation",
+            "registryId": "entity.bing_parent_location",
+            "typeRegistryId": "type.entity_reference",
+            "type": {
+              "documentType": "DOCUMENT_TYPE_ENTITY"
+            }
+          }
+        },
+        {
+          "name": "bingRelationshipType",
+          "definition": {
+            "name": "bingRelationshipType",
+            "registryId": "entity.bing_relationship_type",
+            "typeRegistryId": "type.option",
+            "type": {
+              "stringType": "STRING_TYPE_OPTION"
+            },
+            "options": [
+              {
+                "textValue": "LOCATED_IN",
+                "displayName": "Located In"
+              },
+              {
+                "textValue": "DEPARTMENT_OF",
+                "displayName": "Department Of"
+              },
+              {
+                "textValue": "WORKS_AT",
+                "displayName": "Works At"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bingWebsiteOverride",
+          "definition": {
+            "name": "bingWebsiteOverride",
+            "registryId": "entity.bing_website_override",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_URL"
+            }
+          }
+        },
+        {
+          "name": "blackOwnedBusiness",
+          "definition": {
+            "name": "blackOwnedBusiness",
+            "registryId": "entity.black_owned_business",
+            "typeRegistryId": "type.boolean",
+            "type": {
+              "booleanType": "BOOLEAN_TYPE_DEFAULT"
+            }
+          }
+        },
+        {
+          "name": "brunchHours",
+          "definition": {
+            "name": "brunchHours",
+            "registryId": "entity.brunch_hours",
+            "typeRegistryId": "type.hours",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "monday",
+                "definition": {
+                  "name": "monday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "tuesday",
+                "definition": {
+                  "name": "tuesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "wednesday",
+                "definition": {
+                  "name": "wednesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "thursday",
+                "definition": {
+                  "name": "thursday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "friday",
+                "definition": {
+                  "name": "friday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "saturday",
+                "definition": {
+                  "name": "saturday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "sunday",
+                "definition": {
+                  "name": "sunday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "holidayHours",
+                "definition": {
+                  "name": "holidayHours",
+                  "typeRegistryId": "type.holiday_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  },
+                  "isList": true
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "date",
+                      "definition": {
+                        "name": "date",
+                        "typeRegistryId": "type.date",
+                        "type": {
+                          "stringType": "STRING_TYPE_DATE"
+                        }
+                      }
+                    },
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    },
+                    {
+                      "name": "isRegularHours",
+                      "definition": {
+                        "name": "isRegularHours",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "reopenDate",
+                "definition": {
+                  "name": "reopenDate",
+                  "typeRegistryId": "type.date",
+                  "type": {
+                    "stringType": "STRING_TYPE_DATE"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "covid19InformationUrl",
+          "definition": {
+            "name": "covid19InformationUrl",
+            "registryId": "entity.covid_19_information_url",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_URL"
+            }
+          }
+        },
+        {
+          "name": "covidMessaging",
+          "definition": {
+            "name": "covidMessaging",
+            "registryId": "entity.covid_messaging",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_MULTILINE"
+            }
+          }
+        },
+        {
+          "name": "deliverListingsWithoutGeocode",
+          "definition": {
+            "name": "deliverListingsWithoutGeocode",
+            "registryId": "entity.deliver_listings_without_geocode",
+            "typeRegistryId": "type.boolean",
+            "type": {
+              "booleanType": "BOOLEAN_TYPE_DEFAULT"
+            }
+          }
+        },
+        {
+          "name": "deliveryHours",
+          "definition": {
+            "name": "deliveryHours",
+            "registryId": "entity.delivery_hours",
+            "typeRegistryId": "type.hours",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "monday",
+                "definition": {
+                  "name": "monday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "tuesday",
+                "definition": {
+                  "name": "tuesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "wednesday",
+                "definition": {
+                  "name": "wednesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "thursday",
+                "definition": {
+                  "name": "thursday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "friday",
+                "definition": {
+                  "name": "friday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "saturday",
+                "definition": {
+                  "name": "saturday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "sunday",
+                "definition": {
+                  "name": "sunday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "holidayHours",
+                "definition": {
+                  "name": "holidayHours",
+                  "typeRegistryId": "type.holiday_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  },
+                  "isList": true
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "date",
+                      "definition": {
+                        "name": "date",
+                        "typeRegistryId": "type.date",
+                        "type": {
+                          "stringType": "STRING_TYPE_DATE"
+                        }
+                      }
+                    },
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    },
+                    {
+                      "name": "isRegularHours",
+                      "definition": {
+                        "name": "isRegularHours",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "reopenDate",
+                "definition": {
+                  "name": "reopenDate",
+                  "typeRegistryId": "type.date",
+                  "type": {
+                    "stringType": "STRING_TYPE_DATE"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "deliveryUrl",
+          "definition": {
+            "name": "deliveryUrl",
+            "registryId": "entity.delivery_url",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_URL"
+            }
+          }
+        },
+        {
+          "name": "dineInHours",
+          "definition": {
+            "name": "dineInHours",
+            "registryId": "entity.dine_in_hours",
+            "typeRegistryId": "type.hours",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "monday",
+                "definition": {
+                  "name": "monday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "tuesday",
+                "definition": {
+                  "name": "tuesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "wednesday",
+                "definition": {
+                  "name": "wednesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "thursday",
+                "definition": {
+                  "name": "thursday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "friday",
+                "definition": {
+                  "name": "friday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "saturday",
+                "definition": {
+                  "name": "saturday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "sunday",
+                "definition": {
+                  "name": "sunday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "holidayHours",
+                "definition": {
+                  "name": "holidayHours",
+                  "typeRegistryId": "type.holiday_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  },
+                  "isList": true
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "date",
+                      "definition": {
+                        "name": "date",
+                        "typeRegistryId": "type.date",
+                        "type": {
+                          "stringType": "STRING_TYPE_DATE"
+                        }
+                      }
+                    },
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    },
+                    {
+                      "name": "isRegularHours",
+                      "definition": {
+                        "name": "isRegularHours",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "reopenDate",
+                "definition": {
+                  "name": "reopenDate",
+                  "typeRegistryId": "type.date",
+                  "type": {
+                    "stringType": "STRING_TYPE_DATE"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "driveThroughHours",
+          "definition": {
+            "name": "driveThroughHours",
+            "registryId": "entity.drive_through_hours",
+            "typeRegistryId": "type.hours",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "monday",
+                "definition": {
+                  "name": "monday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "tuesday",
+                "definition": {
+                  "name": "tuesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "wednesday",
+                "definition": {
+                  "name": "wednesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "thursday",
+                "definition": {
+                  "name": "thursday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "friday",
+                "definition": {
+                  "name": "friday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "saturday",
+                "definition": {
+                  "name": "saturday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "sunday",
+                "definition": {
+                  "name": "sunday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "holidayHours",
+                "definition": {
+                  "name": "holidayHours",
+                  "typeRegistryId": "type.holiday_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  },
+                  "isList": true
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "date",
+                      "definition": {
+                        "name": "date",
+                        "typeRegistryId": "type.date",
+                        "type": {
+                          "stringType": "STRING_TYPE_DATE"
+                        }
+                      }
+                    },
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    },
+                    {
+                      "name": "isRegularHours",
+                      "definition": {
+                        "name": "isRegularHours",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "reopenDate",
+                "definition": {
+                  "name": "reopenDate",
+                  "typeRegistryId": "type.date",
+                  "type": {
+                    "stringType": "STRING_TYPE_DATE"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "facebookWebsiteOverride",
+          "definition": {
+            "name": "facebookWebsiteOverride",
+            "registryId": "entity.facebook_website_override",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_URL"
+            }
+          }
+        },
+        {
+          "name": "fullyVaccinatedStaff",
+          "definition": {
+            "name": "fullyVaccinatedStaff",
+            "registryId": "entity.fully_vaccinated_staff",
+            "typeRegistryId": "type.boolean",
+            "type": {
+              "booleanType": "BOOLEAN_TYPE_DEFAULT"
+            }
+          }
+        },
+        {
+          "name": "geomodifier",
+          "definition": {
+            "name": "geomodifier",
+            "registryId": "entity.geomodifier",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_DEFAULT"
+            }
+          }
+        },
+        {
+          "name": "happyHours",
+          "definition": {
+            "name": "happyHours",
+            "registryId": "entity.happy_hours",
+            "typeRegistryId": "type.hours",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "monday",
+                "definition": {
+                  "name": "monday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "tuesday",
+                "definition": {
+                  "name": "tuesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "wednesday",
+                "definition": {
+                  "name": "wednesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "thursday",
+                "definition": {
+                  "name": "thursday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "friday",
+                "definition": {
+                  "name": "friday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "saturday",
+                "definition": {
+                  "name": "saturday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "sunday",
+                "definition": {
+                  "name": "sunday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "holidayHours",
+                "definition": {
+                  "name": "holidayHours",
+                  "typeRegistryId": "type.holiday_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  },
+                  "isList": true
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "date",
+                      "definition": {
+                        "name": "date",
+                        "typeRegistryId": "type.date",
+                        "type": {
+                          "stringType": "STRING_TYPE_DATE"
+                        }
+                      }
+                    },
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    },
+                    {
+                      "name": "isRegularHours",
+                      "definition": {
+                        "name": "isRegularHours",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "reopenDate",
+                "definition": {
+                  "name": "reopenDate",
+                  "typeRegistryId": "type.date",
+                  "type": {
+                    "stringType": "STRING_TYPE_DATE"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "holidayHoursConversationEnabled",
+          "definition": {
+            "name": "holidayHoursConversationEnabled",
+            "registryId": "entity.holiday_hours_conversation_enabled",
+            "typeRegistryId": "type.boolean",
+            "type": {
+              "booleanType": "BOOLEAN_TYPE_DEFAULT"
+            }
+          }
+        },
+        {
+          "name": "kitchenHours",
+          "definition": {
+            "name": "kitchenHours",
+            "registryId": "entity.kitchen_hours",
+            "typeRegistryId": "type.hours",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "monday",
+                "definition": {
+                  "name": "monday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "tuesday",
+                "definition": {
+                  "name": "tuesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "wednesday",
+                "definition": {
+                  "name": "wednesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "thursday",
+                "definition": {
+                  "name": "thursday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "friday",
+                "definition": {
+                  "name": "friday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "saturday",
+                "definition": {
+                  "name": "saturday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "sunday",
+                "definition": {
+                  "name": "sunday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "holidayHours",
+                "definition": {
+                  "name": "holidayHours",
+                  "typeRegistryId": "type.holiday_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  },
+                  "isList": true
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "date",
+                      "definition": {
+                        "name": "date",
+                        "typeRegistryId": "type.date",
+                        "type": {
+                          "stringType": "STRING_TYPE_DATE"
+                        }
+                      }
+                    },
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    },
+                    {
+                      "name": "isRegularHours",
+                      "definition": {
+                        "name": "isRegularHours",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "reopenDate",
+                "definition": {
+                  "name": "reopenDate",
+                  "typeRegistryId": "type.date",
+                  "type": {
+                    "stringType": "STRING_TYPE_DATE"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "landingPageUrl",
+          "definition": {
+            "name": "landingPageUrl",
+            "registryId": "entity.landing_page_url",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_URL"
+            }
+          }
+        },
+        {
+          "name": "linkedInUrl",
+          "definition": {
+            "name": "linkedInUrl",
+            "registryId": "entity.linkedin_url",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_URL"
+            }
+          }
+        },
+        {
+          "name": "neighborhood",
+          "definition": {
+            "name": "neighborhood",
+            "registryId": "entity.neighborhood",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_DEFAULT"
+            }
+          }
+        },
+        {
+          "name": "nudgeEnabled",
+          "definition": {
+            "name": "nudgeEnabled",
+            "registryId": "entity.nudge_conversation_enabled",
+            "typeRegistryId": "type.boolean",
+            "type": {
+              "booleanType": "BOOLEAN_TYPE_DEFAULT"
+            }
+          }
+        },
+        {
+          "name": "onlineServiceHours",
+          "definition": {
+            "name": "onlineServiceHours",
+            "registryId": "entity.online_service_hours",
+            "typeRegistryId": "type.hours",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "monday",
+                "definition": {
+                  "name": "monday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "tuesday",
+                "definition": {
+                  "name": "tuesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "wednesday",
+                "definition": {
+                  "name": "wednesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "thursday",
+                "definition": {
+                  "name": "thursday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "friday",
+                "definition": {
+                  "name": "friday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "saturday",
+                "definition": {
+                  "name": "saturday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "sunday",
+                "definition": {
+                  "name": "sunday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "holidayHours",
+                "definition": {
+                  "name": "holidayHours",
+                  "typeRegistryId": "type.holiday_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  },
+                  "isList": true
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "date",
+                      "definition": {
+                        "name": "date",
+                        "typeRegistryId": "type.date",
+                        "type": {
+                          "stringType": "STRING_TYPE_DATE"
+                        }
+                      }
+                    },
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    },
+                    {
+                      "name": "isRegularHours",
+                      "definition": {
+                        "name": "isRegularHours",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "reopenDate",
+                "definition": {
+                  "name": "reopenDate",
+                  "typeRegistryId": "type.date",
+                  "type": {
+                    "stringType": "STRING_TYPE_DATE"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "phoneticName",
+          "definition": {
+            "name": "phoneticName",
+            "registryId": "entity.phonetic_name",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_DEFAULT"
+            }
+          }
+        },
+        {
+          "name": "pickupAndDeliveryServices",
+          "definition": {
+            "name": "pickupAndDeliveryServices",
+            "registryId": "entity.pickup_and_delivery_services",
+            "typeRegistryId": "type.option",
+            "type": {
+              "stringType": "STRING_TYPE_OPTION"
+            },
+            "isList": true,
+            "options": [
+              {
+                "textValue": "IN_STORE_PICKUP",
+                "displayName": "In-Store Pickup"
+              },
+              {
+                "textValue": "CURBSIDE_PICKUP",
+                "displayName": "Curbside Pickup"
+              },
+              {
+                "textValue": "PICKUP_NOT_OFFERED",
+                "displayName": "Pickup Not Offered"
+              },
+              {
+                "textValue": "DELIVERY",
+                "displayName": "Delivery"
+              },
+              {
+                "textValue": "SAME_DAY_DELIVERY",
+                "displayName": "Same Day Delivery"
+              },
+              {
+                "textValue": "NO_CONTACT_DELIVERY",
+                "displayName": "No-Contact Delivery"
+              },
+              {
+                "textValue": "DELIVERY_NOT_OFFERED",
+                "displayName": "Delivery Not Offered"
+              }
+            ]
+          }
+        },
+        {
+          "name": "pickupHours",
+          "definition": {
+            "name": "pickupHours",
+            "registryId": "entity.pickup_hours",
+            "typeRegistryId": "type.hours",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "monday",
+                "definition": {
+                  "name": "monday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "tuesday",
+                "definition": {
+                  "name": "tuesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "wednesday",
+                "definition": {
+                  "name": "wednesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "thursday",
+                "definition": {
+                  "name": "thursday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "friday",
+                "definition": {
+                  "name": "friday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "saturday",
+                "definition": {
+                  "name": "saturday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "sunday",
+                "definition": {
+                  "name": "sunday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "holidayHours",
+                "definition": {
+                  "name": "holidayHours",
+                  "typeRegistryId": "type.holiday_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  },
+                  "isList": true
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "date",
+                      "definition": {
+                        "name": "date",
+                        "typeRegistryId": "type.date",
+                        "type": {
+                          "stringType": "STRING_TYPE_DATE"
+                        }
+                      }
+                    },
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    },
+                    {
+                      "name": "isRegularHours",
+                      "definition": {
+                        "name": "isRegularHours",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "reopenDate",
+                "definition": {
+                  "name": "reopenDate",
+                  "typeRegistryId": "type.date",
+                  "type": {
+                    "stringType": "STRING_TYPE_DATE"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "primaryConversationContact",
+          "definition": {
+            "name": "primaryConversationContact",
+            "registryId": "entity.primary_conversation_contact",
+            "typeRegistryId": "type.user_reference",
+            "type": {
+              "stringType": "STRING_TYPE_DEFAULT"
+            }
+          }
+        },
+        {
+          "name": "proofOfVaccinationRequired",
+          "definition": {
+            "name": "proofOfVaccinationRequired",
+            "registryId": "entity.proof_of_vaccination_required",
+            "typeRegistryId": "type.boolean",
+            "type": {
+              "booleanType": "BOOLEAN_TYPE_DEFAULT"
+            }
+          }
+        },
+        {
+          "name": "reviewResponseConversationEnabled",
+          "definition": {
+            "name": "reviewResponseConversationEnabled",
+            "registryId": "entity.review_response_conversation_enabled",
+            "typeRegistryId": "type.boolean",
+            "type": {
+              "booleanType": "BOOLEAN_TYPE_DEFAULT"
+            }
+          }
+        },
+        {
+          "name": "seniorHours",
+          "definition": {
+            "name": "seniorHours",
+            "registryId": "entity.senior_hours",
+            "typeRegistryId": "type.hours",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "monday",
+                "definition": {
+                  "name": "monday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "tuesday",
+                "definition": {
+                  "name": "tuesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "wednesday",
+                "definition": {
+                  "name": "wednesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "thursday",
+                "definition": {
+                  "name": "thursday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "friday",
+                "definition": {
+                  "name": "friday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "saturday",
+                "definition": {
+                  "name": "saturday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "sunday",
+                "definition": {
+                  "name": "sunday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "holidayHours",
+                "definition": {
+                  "name": "holidayHours",
+                  "typeRegistryId": "type.holiday_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  },
+                  "isList": true
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "date",
+                      "definition": {
+                        "name": "date",
+                        "typeRegistryId": "type.date",
+                        "type": {
+                          "stringType": "STRING_TYPE_DATE"
+                        }
+                      }
+                    },
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    },
+                    {
+                      "name": "isRegularHours",
+                      "definition": {
+                        "name": "isRegularHours",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "reopenDate",
+                "definition": {
+                  "name": "reopenDate",
+                  "typeRegistryId": "type.date",
+                  "type": {
+                    "stringType": "STRING_TYPE_DATE"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "slug",
+          "definition": {
+            "name": "slug",
+            "registryId": "entity.slug",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_DEFAULT"
+            }
+          }
+        },
+        {
+          "name": "takeoutHours",
+          "definition": {
+            "name": "takeoutHours",
+            "registryId": "entity.takeout_hours",
+            "typeRegistryId": "type.hours",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "monday",
+                "definition": {
+                  "name": "monday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "tuesday",
+                "definition": {
+                  "name": "tuesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "wednesday",
+                "definition": {
+                  "name": "wednesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "thursday",
+                "definition": {
+                  "name": "thursday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "friday",
+                "definition": {
+                  "name": "friday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "saturday",
+                "definition": {
+                  "name": "saturday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "sunday",
+                "definition": {
+                  "name": "sunday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "holidayHours",
+                "definition": {
+                  "name": "holidayHours",
+                  "typeRegistryId": "type.holiday_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  },
+                  "isList": true
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "date",
+                      "definition": {
+                        "name": "date",
+                        "typeRegistryId": "type.date",
+                        "type": {
+                          "stringType": "STRING_TYPE_DATE"
+                        }
+                      }
+                    },
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    },
+                    {
+                      "name": "isRegularHours",
+                      "definition": {
+                        "name": "isRegularHours",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "reopenDate",
+                "definition": {
+                  "name": "reopenDate",
+                  "typeRegistryId": "type.date",
+                  "type": {
+                    "stringType": "STRING_TYPE_DATE"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "inBound",
+          "definition": {
+            "name": "inBound",
+            "registryId": "entity.testInbound",
+            "typeRegistryId": "type.entity_reference",
+            "type": {
+              "documentType": "DOCUMENT_TYPE_ENTITY"
+            },
+            "isList": true
+          }
+        },
+        {
+          "name": "outBound",
+          "definition": {
+            "name": "outBound",
+            "registryId": "entity.testOutbound",
+            "typeRegistryId": "type.entity_reference",
+            "type": {
+              "documentType": "DOCUMENT_TYPE_ENTITY"
+            },
+            "isList": true
+          }
+        },
+        {
+          "name": "what3WordsAddress",
+          "definition": {
+            "name": "what3WordsAddress",
+            "registryId": "entity.what_3_words_address",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_DEFAULT"
+            }
+          }
+        },
+        {
+          "name": "yelpWebsiteOverride",
+          "definition": {
+            "name": "yelpWebsiteOverride",
+            "registryId": "entity.yelp_website_override",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_URL"
+            }
+          }
+        },
+        {
+          "name": "additionalHoursText",
+          "definition": {
+            "name": "additionalHoursText",
+            "registryId": "location.additional_hours_text",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_DEFAULT"
+            }
+          }
+        },
+        {
+          "name": "address",
+          "definition": {
+            "name": "address",
+            "registryId": "location.address",
+            "typeRegistryId": "type.address",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "line1",
+                "definition": {
+                  "name": "line1",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  }
+                }
+              },
+              {
+                "name": "line2",
+                "definition": {
+                  "name": "line2",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  }
+                }
+              },
+              {
+                "name": "line3",
+                "definition": {
+                  "name": "line3",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  }
+                }
+              },
+              {
+                "name": "sublocality",
+                "definition": {
+                  "name": "sublocality",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  }
+                }
+              },
+              {
+                "name": "city",
+                "definition": {
+                  "name": "city",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  }
+                }
+              },
+              {
+                "name": "region",
+                "definition": {
+                  "name": "region",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  }
+                }
+              },
+              {
+                "name": "postalCode",
+                "definition": {
+                  "name": "postalCode",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  }
+                }
+              },
+              {
+                "name": "extraDescription",
+                "definition": {
+                  "name": "extraDescription",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  }
+                }
+              },
+              {
+                "name": "countryCode",
+                "definition": {
+                  "name": "countryCode",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "addressHidden",
+          "definition": {
+            "name": "addressHidden",
+            "registryId": "location.address_hidden",
+            "typeRegistryId": "type.boolean",
+            "type": {
+              "booleanType": "BOOLEAN_TYPE_DEFAULT"
+            }
+          }
+        },
+        {
+          "name": "alternatePhone",
+          "definition": {
+            "name": "alternatePhone",
+            "registryId": "location.alternate_phone",
+            "typeRegistryId": "type.phone",
+            "type": {
+              "stringType": "STRING_TYPE_PHONE"
+            }
+          }
+        },
+        {
+          "name": "androidAppUrl",
+          "definition": {
+            "name": "androidAppUrl",
+            "registryId": "location.android_app_url",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_URL"
+            }
+          }
+        },
+        {
+          "name": "associations",
+          "definition": {
+            "name": "associations",
+            "registryId": "location.associations",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_DEFAULT"
+            },
+            "isList": true
+          }
+        },
+        {
+          "name": "brands",
+          "definition": {
+            "name": "brands",
+            "registryId": "location.brands",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_DEFAULT"
+            },
+            "isList": true
+          }
+        },
+        {
+          "name": "description",
+          "definition": {
+            "name": "description",
+            "registryId": "location.business_description",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_MULTILINE"
+            }
+          }
+        },
+        {
+          "name": "hours",
+          "definition": {
+            "name": "hours",
+            "registryId": "location.business_hours",
+            "typeRegistryId": "type.hours",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "monday",
+                "definition": {
+                  "name": "monday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "tuesday",
+                "definition": {
+                  "name": "tuesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "wednesday",
+                "definition": {
+                  "name": "wednesday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "thursday",
+                "definition": {
+                  "name": "thursday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "friday",
+                "definition": {
+                  "name": "friday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "saturday",
+                "definition": {
+                  "name": "saturday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "sunday",
+                "definition": {
+                  "name": "sunday",
+                  "typeRegistryId": "type.day_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "holidayHours",
+                "definition": {
+                  "name": "holidayHours",
+                  "typeRegistryId": "type.holiday_hour",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  },
+                  "isList": true
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "date",
+                      "definition": {
+                        "name": "date",
+                        "typeRegistryId": "type.date",
+                        "type": {
+                          "stringType": "STRING_TYPE_DATE"
+                        }
+                      }
+                    },
+                    {
+                      "name": "openIntervals",
+                      "definition": {
+                        "name": "openIntervals",
+                        "typeRegistryId": "type.interval",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_DEFAULT"
+                        },
+                        "isList": true
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "start",
+                            "definition": {
+                              "name": "start",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          },
+                          {
+                            "name": "end",
+                            "definition": {
+                              "name": "end",
+                              "typeRegistryId": "type.time",
+                              "type": {
+                                "stringType": "STRING_TYPE_LOCAL_TIME"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "isClosed",
+                      "definition": {
+                        "name": "isClosed",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    },
+                    {
+                      "name": "isRegularHours",
+                      "definition": {
+                        "name": "isRegularHours",
+                        "typeRegistryId": "type.boolean",
+                        "type": {
+                          "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "reopenDate",
+                "definition": {
+                  "name": "reopenDate",
+                  "typeRegistryId": "type.date",
+                  "type": {
+                    "stringType": "STRING_TYPE_DATE"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "logo",
+          "definition": {
+            "name": "logo",
+            "registryId": "location.business_logo",
+            "typeRegistryId": "type.image",
+            "type": {
+              "objectType": "OBJECT_TYPE_COMPLEX_IMAGE"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "image",
+                "definition": {
+                  "name": "image",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_IMAGE"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "url",
+                      "definition": {
+                        "name": "url",
+                        "type": {
+                          "stringType": "STRING_TYPE_URL"
+                        }
+                      }
+                    },
+                    {
+                      "name": "alternateText",
+                      "definition": {
+                        "name": "alternateText",
+                        "type": {
+                          "stringType": "STRING_TYPE_MULTILINE"
+                        }
+                      }
+                    },
+                    {
+                      "name": "width",
+                      "definition": {
+                        "name": "width",
+                        "type": {
+                          "numberType": "NUMBER_TYPE_INT"
+                        }
+                      }
+                    },
+                    {
+                      "name": "height",
+                      "definition": {
+                        "name": "height",
+                        "type": {
+                          "numberType": "NUMBER_TYPE_INT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "description",
+                "definition": {
+                  "name": "description",
+                  "type": {
+                    "stringType": "STRING_TYPE_MULTILINE"
+                  }
+                }
+              },
+              {
+                "name": "details",
+                "definition": {
+                  "name": "details",
+                  "type": {
+                    "stringType": "STRING_TYPE_MULTILINE"
+                  }
+                }
+              },
+              {
+                "name": "clickthroughUrl",
+                "definition": {
+                  "name": "clickthroughUrl",
+                  "type": {
+                    "stringType": "STRING_TYPE_URL"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "name",
+          "definition": {
+            "name": "name",
+            "registryId": "location.business_name",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_DEFAULT"
+            }
+          }
+        },
+        {
+          "name": "cityCoordinate",
+          "definition": {
+            "name": "cityCoordinate",
+            "registryId": "location.city_coordinate",
+            "typeRegistryId": "type.coordinate",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "latitude",
+                "definition": {
+                  "name": "latitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              },
+              {
+                "name": "longitude",
+                "definition": {
+                  "name": "longitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "closed",
+          "definition": {
+            "name": "closed",
+            "registryId": "location.closed",
+            "typeRegistryId": "type.boolean",
+            "type": {
+              "booleanType": "BOOLEAN_TYPE_DEFAULT"
+            }
+          }
+        },
+        {
+          "name": "c_callToAction",
+          "definition": {
+            "name": "c_callToAction",
+            "registryId": "location.custom.1000146856.call_to_action.0",
+            "typeRegistryId": "type.cta",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "label",
+                "definition": {
+                  "name": "label",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  }
+                }
+              },
+              {
+                "name": "linkType",
+                "definition": {
+                  "name": "linkType",
+                  "typeRegistryId": "type.option",
+                  "type": {
+                    "stringType": "STRING_TYPE_OPTION"
+                  },
+                  "options": [
+                    {
+                      "textValue": "OTHER",
+                      "displayName": "Other"
+                    },
+                    {
+                      "textValue": "URL",
+                      "displayName": "URL"
+                    },
+                    {
+                      "textValue": "PHONE",
+                      "displayName": "Phone"
+                    },
+                    {
+                      "textValue": "EMAIL",
+                      "displayName": "Email"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "link",
+                "definition": {
+                  "name": "link",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "c_deliveryPromo",
+          "definition": {
+            "name": "c_deliveryPromo",
+            "registryId": "location.custom.1000146856.delivery_promo.0",
+            "typeName": "c_promoSection",
+            "typeRegistryId": "type.c1000146856.promosection",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "image",
+                "definition": {
+                  "name": "image",
+                  "typeRegistryId": "type.image",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_COMPLEX_IMAGE"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "image",
+                      "definition": {
+                        "name": "image",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_IMAGE"
+                        }
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "url",
+                            "definition": {
+                              "name": "url",
+                              "type": {
+                                "stringType": "STRING_TYPE_URL"
+                              }
+                            }
+                          },
+                          {
+                            "name": "alternateText",
+                            "definition": {
+                              "name": "alternateText",
+                              "type": {
+                                "stringType": "STRING_TYPE_MULTILINE"
+                              }
+                            }
+                          },
+                          {
+                            "name": "width",
+                            "definition": {
+                              "name": "width",
+                              "type": {
+                                "numberType": "NUMBER_TYPE_INT"
+                              }
+                            }
+                          },
+                          {
+                            "name": "height",
+                            "definition": {
+                              "name": "height",
+                              "type": {
+                                "numberType": "NUMBER_TYPE_INT"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "description",
+                      "definition": {
+                        "name": "description",
+                        "type": {
+                          "stringType": "STRING_TYPE_MULTILINE"
+                        }
+                      }
+                    },
+                    {
+                      "name": "details",
+                      "definition": {
+                        "name": "details",
+                        "type": {
+                          "stringType": "STRING_TYPE_MULTILINE"
+                        }
+                      }
+                    },
+                    {
+                      "name": "clickthroughUrl",
+                      "definition": {
+                        "name": "clickthroughUrl",
+                        "type": {
+                          "stringType": "STRING_TYPE_URL"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "title",
+                "definition": {
+                  "name": "title",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  }
+                }
+              },
+              {
+                "name": "description",
+                "definition": {
+                  "name": "description",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_MULTILINE"
+                  }
+                }
+              },
+              {
+                "name": "cta",
+                "definition": {
+                  "name": "cta",
+                  "typeName": "c_cta",
+                  "typeRegistryId": "type.c1000146856.cta",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "name",
+                      "definition": {
+                        "name": "name",
+                        "typeRegistryId": "type.string",
+                        "type": {
+                          "stringType": "STRING_TYPE_DEFAULT"
+                        }
+                      }
+                    },
+                    {
+                      "name": "link",
+                      "definition": {
+                        "name": "link",
+                        "typeRegistryId": "type.string",
+                        "type": {
+                          "stringType": "STRING_TYPE_URL"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "c_faqSection",
+          "definition": {
+            "name": "c_faqSection",
+            "registryId": "location.custom.1000146856.faq_section.0",
+            "typeName": "c_faqSection",
+            "typeRegistryId": "type.c1000146856.faqsection",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "sectionTitle",
+                "definition": {
+                  "name": "sectionTitle",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  }
+                }
+              },
+              {
+                "name": "linkedFAQs",
+                "definition": {
+                  "name": "linkedFAQs",
+                  "typeRegistryId": "type.entity_reference",
+                  "type": {
+                    "documentType": "DOCUMENT_TYPE_ENTITY"
+                  },
+                  "isList": true
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "c_hero",
+          "definition": {
+            "name": "c_hero",
+            "registryId": "location.custom.1000146856.hero.0",
+            "typeName": "c_hero",
+            "typeRegistryId": "type.c1000146856.hero",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "image",
+                "definition": {
+                  "name": "image",
+                  "typeRegistryId": "type.image",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_COMPLEX_IMAGE"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "image",
+                      "definition": {
+                        "name": "image",
+                        "type": {
+                          "objectType": "OBJECT_TYPE_IMAGE"
+                        }
+                      },
+                      "children": {
+                        "fields": [
+                          {
+                            "name": "url",
+                            "definition": {
+                              "name": "url",
+                              "type": {
+                                "stringType": "STRING_TYPE_URL"
+                              }
+                            }
+                          },
+                          {
+                            "name": "alternateText",
+                            "definition": {
+                              "name": "alternateText",
+                              "type": {
+                                "stringType": "STRING_TYPE_MULTILINE"
+                              }
+                            }
+                          },
+                          {
+                            "name": "width",
+                            "definition": {
+                              "name": "width",
+                              "type": {
+                                "numberType": "NUMBER_TYPE_INT"
+                              }
+                            }
+                          },
+                          {
+                            "name": "height",
+                            "definition": {
+                              "name": "height",
+                              "type": {
+                                "numberType": "NUMBER_TYPE_INT"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "description",
+                      "definition": {
+                        "name": "description",
+                        "type": {
+                          "stringType": "STRING_TYPE_MULTILINE"
+                        }
+                      }
+                    },
+                    {
+                      "name": "details",
+                      "definition": {
+                        "name": "details",
+                        "type": {
+                          "stringType": "STRING_TYPE_MULTILINE"
+                        }
+                      }
+                    },
+                    {
+                      "name": "clickthroughUrl",
+                      "definition": {
+                        "name": "clickthroughUrl",
+                        "type": {
+                          "stringType": "STRING_TYPE_URL"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "cta1",
+                "definition": {
+                  "name": "cta1",
+                  "typeName": "c_cta",
+                  "typeRegistryId": "type.c1000146856.cta",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "name",
+                      "definition": {
+                        "name": "name",
+                        "typeRegistryId": "type.string",
+                        "type": {
+                          "stringType": "STRING_TYPE_DEFAULT"
+                        }
+                      }
+                    },
+                    {
+                      "name": "link",
+                      "definition": {
+                        "name": "link",
+                        "typeRegistryId": "type.string",
+                        "type": {
+                          "stringType": "STRING_TYPE_URL"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "cta2",
+                "definition": {
+                  "name": "cta2",
+                  "typeName": "c_cta",
+                  "typeRegistryId": "type.c1000146856.cta",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "name",
+                      "definition": {
+                        "name": "name",
+                        "typeRegistryId": "type.string",
+                        "type": {
+                          "stringType": "STRING_TYPE_DEFAULT"
+                        }
+                      }
+                    },
+                    {
+                      "name": "link",
+                      "definition": {
+                        "name": "link",
+                        "typeRegistryId": "type.string",
+                        "type": {
+                          "stringType": "STRING_TYPE_URL"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "c_productSection",
+          "definition": {
+            "name": "c_productSection",
+            "registryId": "location.custom.1000146856.product_section.0",
+            "typeName": "c_productSection",
+            "typeRegistryId": "type.c1000146856.productsection",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "sectionTitle",
+                "definition": {
+                  "name": "sectionTitle",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  }
+                }
+              },
+              {
+                "name": "linkedProducts",
+                "definition": {
+                  "name": "linkedProducts",
+                  "typeRegistryId": "type.entity_reference",
+                  "type": {
+                    "documentType": "DOCUMENT_TYPE_ENTITY"
+                  },
+                  "isList": true
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "displayCoordinate",
+          "definition": {
+            "name": "displayCoordinate",
+            "registryId": "location.display_coordinate",
+            "typeRegistryId": "type.coordinate",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "latitude",
+                "definition": {
+                  "name": "latitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              },
+              {
+                "name": "longitude",
+                "definition": {
+                  "name": "longitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "dropoffCoordinate",
+          "definition": {
+            "name": "dropoffCoordinate",
+            "registryId": "location.dropoff_coordinate",
+            "typeRegistryId": "type.coordinate",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "latitude",
+                "definition": {
+                  "name": "latitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              },
+              {
+                "name": "longitude",
+                "definition": {
+                  "name": "longitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "bios",
+          "definition": {
+            "name": "bios",
+            "registryId": "location.ecls.bios",
+            "typeRegistryId": "type.bio_ecl_list",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "label",
+                "definition": {
+                  "name": "label",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  }
+                }
+              },
+              {
+                "name": "ids",
+                "definition": {
+                  "name": "ids",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  },
+                  "isList": true
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "menus",
+          "definition": {
+            "name": "menus",
+            "registryId": "location.ecls.menus",
+            "typeRegistryId": "type.menu_ecl_list",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "label",
+                "definition": {
+                  "name": "label",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  }
+                }
+              },
+              {
+                "name": "ids",
+                "definition": {
+                  "name": "ids",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  },
+                  "isList": true
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "productLists",
+          "definition": {
+            "name": "productLists",
+            "registryId": "location.ecls.products_and_services",
+            "typeRegistryId": "type.product_service_ecl_list",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "label",
+                "definition": {
+                  "name": "label",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  }
+                }
+              },
+              {
+                "name": "ids",
+                "definition": {
+                  "name": "ids",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  },
+                  "isList": true
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "emails",
+          "definition": {
+            "name": "emails",
+            "registryId": "location.emails",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_DEFAULT"
+            },
+            "isList": true
+          }
+        },
+        {
+          "name": "facebookPageUrl",
+          "definition": {
+            "name": "facebookPageUrl",
+            "registryId": "location.facebook_page_url",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_URL"
+            }
+          }
+        },
+        {
+          "name": "fax",
+          "definition": {
+            "name": "fax",
+            "registryId": "location.fax_phone",
+            "typeRegistryId": "type.phone",
+            "type": {
+              "stringType": "STRING_TYPE_PHONE"
+            }
+          }
+        },
+        {
+          "name": "featuredMessage",
+          "definition": {
+            "name": "featuredMessage",
+            "registryId": "location.featured_message",
+            "typeRegistryId": "type.featured_message",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "description",
+                "definition": {
+                  "name": "description",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  }
+                }
+              },
+              {
+                "name": "url",
+                "definition": {
+                  "name": "url",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_URL"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "photoGallery",
+          "definition": {
+            "name": "photoGallery",
+            "registryId": "location.gallery",
+            "typeRegistryId": "type.image",
+            "type": {
+              "objectType": "OBJECT_TYPE_COMPLEX_IMAGE"
+            },
+            "isList": true
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "image",
+                "definition": {
+                  "name": "image",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_IMAGE"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "url",
+                      "definition": {
+                        "name": "url",
+                        "type": {
+                          "stringType": "STRING_TYPE_URL"
+                        }
+                      }
+                    },
+                    {
+                      "name": "alternateText",
+                      "definition": {
+                        "name": "alternateText",
+                        "type": {
+                          "stringType": "STRING_TYPE_MULTILINE"
+                        }
+                      }
+                    },
+                    {
+                      "name": "width",
+                      "definition": {
+                        "name": "width",
+                        "type": {
+                          "numberType": "NUMBER_TYPE_INT"
+                        }
+                      }
+                    },
+                    {
+                      "name": "height",
+                      "definition": {
+                        "name": "height",
+                        "type": {
+                          "numberType": "NUMBER_TYPE_INT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "description",
+                "definition": {
+                  "name": "description",
+                  "type": {
+                    "stringType": "STRING_TYPE_MULTILINE"
+                  }
+                }
+              },
+              {
+                "name": "details",
+                "definition": {
+                  "name": "details",
+                  "type": {
+                    "stringType": "STRING_TYPE_MULTILINE"
+                  }
+                }
+              },
+              {
+                "name": "clickthroughUrl",
+                "definition": {
+                  "name": "clickthroughUrl",
+                  "type": {
+                    "stringType": "STRING_TYPE_URL"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "geocodedCoordinate",
+          "definition": {
+            "name": "geocodedCoordinate",
+            "registryId": "location.geocoded_coordinate",
+            "typeRegistryId": "type.coordinate",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "latitude",
+                "definition": {
+                  "name": "latitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              },
+              {
+                "name": "longitude",
+                "definition": {
+                  "name": "longitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "googleWebsiteOverride",
+          "definition": {
+            "name": "googleWebsiteOverride",
+            "registryId": "location.google_website_override",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_URL"
+            }
+          }
+        },
+        {
+          "name": "instagramHandle",
+          "definition": {
+            "name": "instagramHandle",
+            "registryId": "location.instagram_handle",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_DEFAULT"
+            }
+          }
+        },
+        {
+          "name": "iosAppUrl",
+          "definition": {
+            "name": "iosAppUrl",
+            "registryId": "location.ios_app_url",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_URL"
+            }
+          }
+        },
+        {
+          "name": "isoRegionCode",
+          "definition": {
+            "name": "isoRegionCode",
+            "registryId": "location.iso_region_code",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_DEFAULT"
+            }
+          }
+        },
+        {
+          "name": "keywords",
+          "definition": {
+            "name": "keywords",
+            "registryId": "location.keywords",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_DEFAULT"
+            },
+            "isList": true
+          }
+        },
+        {
+          "name": "labels",
+          "definition": {
+            "name": "labels",
+            "registryId": "location.labels",
+            "typeRegistryId": "type.location_label_list",
+            "type": {
+              "stringType": "STRING_TYPE_DEFAULT"
+            },
+            "isList": true
+          }
+        },
+        {
+          "name": "languages",
+          "definition": {
+            "name": "languages",
+            "registryId": "location.languages",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_DEFAULT"
+            },
+            "isList": true
+          }
+        },
+        {
+          "name": "localPhone",
+          "definition": {
+            "name": "localPhone",
+            "registryId": "location.local_phone",
+            "typeRegistryId": "type.phone",
+            "type": {
+              "stringType": "STRING_TYPE_PHONE"
+            }
+          }
+        },
+        {
+          "name": "mainPhone",
+          "definition": {
+            "name": "mainPhone",
+            "registryId": "location.main_phone",
+            "typeRegistryId": "type.phone",
+            "type": {
+              "stringType": "STRING_TYPE_PHONE"
+            }
+          }
+        },
+        {
+          "name": "menuUrl",
+          "definition": {
+            "name": "menuUrl",
+            "registryId": "location.menu_url",
+            "typeRegistryId": "type.url",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "url",
+                "definition": {
+                  "name": "url",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_URL"
+                  }
+                }
+              },
+              {
+                "name": "displayUrl",
+                "definition": {
+                  "name": "displayUrl",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_URL"
+                  }
+                }
+              },
+              {
+                "name": "preferDisplayUrl",
+                "definition": {
+                  "name": "preferDisplayUrl",
+                  "typeRegistryId": "type.boolean",
+                  "type": {
+                    "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "mobilePhone",
+          "definition": {
+            "name": "mobilePhone",
+            "registryId": "location.mobile_phone",
+            "typeRegistryId": "type.phone",
+            "type": {
+              "stringType": "STRING_TYPE_PHONE"
+            }
+          }
+        },
+        {
+          "name": "orderUrl",
+          "definition": {
+            "name": "orderUrl",
+            "registryId": "location.order_url",
+            "typeRegistryId": "type.url",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "url",
+                "definition": {
+                  "name": "url",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_URL"
+                  }
+                }
+              },
+              {
+                "name": "displayUrl",
+                "definition": {
+                  "name": "displayUrl",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_URL"
+                  }
+                }
+              },
+              {
+                "name": "preferDisplayUrl",
+                "definition": {
+                  "name": "preferDisplayUrl",
+                  "typeRegistryId": "type.boolean",
+                  "type": {
+                    "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "paymentOptions",
+          "definition": {
+            "name": "paymentOptions",
+            "registryId": "location.payment_methods",
+            "typeRegistryId": "type.option",
+            "type": {
+              "stringType": "STRING_TYPE_OPTION"
+            },
+            "isList": true,
+            "options": [
+              {
+                "textValue": "ALIPAY",
+                "displayName": "AliPay"
+              },
+              {
+                "textValue": "AMERICANEXPRESS",
+                "displayName": "American Express"
+              },
+              {
+                "textValue": "ANDROIDPAY",
+                "displayName": "Google Pay"
+              },
+              {
+                "textValue": "APPLEPAY",
+                "displayName": "Apple Pay"
+              },
+              {
+                "textValue": "ATM",
+                "displayName": "ATM"
+              },
+              {
+                "textValue": "ATMQUICK",
+                "displayName": "ATM Quick"
+              },
+              {
+                "textValue": "BACS",
+                "displayName": "BACS"
+              },
+              {
+                "textValue": "BANCONTACT",
+                "displayName": "Bancontact"
+              },
+              {
+                "textValue": "BANKCARD",
+                "displayName": "Bank Card"
+              },
+              {
+                "textValue": "BANKDEPOSIT",
+                "displayName": "Bank Deposit"
+              },
+              {
+                "textValue": "BANKPAY",
+                "displayName": "Bank Pay"
+              },
+              {
+                "textValue": "BGO",
+                "displayName": "Bank/Giro Overschrijving"
+              },
+              {
+                "textValue": "BITCOIN",
+                "displayName": "Bitcoin"
+              },
+              {
+                "textValue": "Bar",
+                "displayName": "Bargeld"
+              },
+              {
+                "textValue": "CARTASI",
+                "displayName": "CartaSi"
+              },
+              {
+                "textValue": "CARTECADEAUX",
+                "displayName": "Carte cadeaux"
+              },
+              {
+                "textValue": "CASH",
+                "displayName": "Cash"
+              },
+              {
+                "textValue": "CCS",
+                "displayName": "CCS"
+              },
+              {
+                "textValue": "CHECK",
+                "displayName": "Check"
+              },
+              {
+                "textValue": "CHEQUESVACANCES",
+                "displayName": "Chèques vacances"
+              },
+              {
+                "textValue": "CONB",
+                "displayName": "Contactloos betalen"
+              },
+              {
+                "textValue": "CVVV",
+                "displayName": "Cadeaubon/VVV bon"
+              },
+              {
+                "textValue": "DEBITCARD",
+                "displayName": "Debit Card"
+              },
+              {
+                "textValue": "DEBITNOTE",
+                "displayName": "Debit Note"
+              },
+              {
+                "textValue": "DINERSCLUB",
+                "displayName": "Diners Club"
+              },
+              {
+                "textValue": "DIRECTDEBIT",
+                "displayName": "Direct Debit"
+              },
+              {
+                "textValue": "DISCOVER",
+                "displayName": "Discover"
+              },
+              {
+                "textValue": "ECKARTE",
+                "displayName": "Girokarte"
+              },
+              {
+                "textValue": "ECOCHEQUE",
+                "displayName": "EcoCheque"
+              },
+              {
+                "textValue": "EKENA",
+                "displayName": "E-kena"
+              },
+              {
+                "textValue": "EMV",
+                "displayName": "Elektronische Maaltijdcheques"
+              },
+              {
+                "textValue": "FINANCING",
+                "displayName": "Financing"
+              },
+              {
+                "textValue": "GIFTCARD",
+                "displayName": "Gift Card"
+              },
+              {
+                "textValue": "GOPAY",
+                "displayName": "GoPay"
+              },
+              {
+                "textValue": "HAYAKAKEN",
+                "displayName": "Hayakaken"
+              },
+              {
+                "textValue": "HEBAG",
+                "displayName": "He-Bag"
+              },
+              {
+                "textValue": "IBOD",
+                "displayName": "iBOD"
+              },
+              {
+                "textValue": "ICCARDS",
+                "displayName": "IC Cards"
+              },
+              {
+                "textValue": "ICOCA",
+                "displayName": "Icoca"
+              },
+              {
+                "textValue": "ID",
+                "displayName": "iD"
+              },
+              {
+                "textValue": "IDEAL",
+                "displayName": "iDeal"
+              },
+              {
+                "textValue": "INCA",
+                "displayName": "Incasso"
+              },
+              {
+                "textValue": "INVOICE",
+                "displayName": "Invoice"
+              },
+              {
+                "textValue": "JCB",
+                "displayName": "JCB"
+              },
+              {
+                "textValue": "JCoinPay",
+                "displayName": "J−Coin Pay"
+              },
+              {
+                "textValue": "JKOPAY",
+                "displayName": "JKO Pay"
+              },
+              {
+                "textValue": "KITACA",
+                "displayName": "Kitaca"
+              },
+              {
+                "textValue": "KLA",
+                "displayName": "Klantenkaart"
+              },
+              {
+                "textValue": "KLARNA",
+                "displayName": "Klarna"
+              },
+              {
+                "textValue": "LINEPAY",
+                "displayName": "LINE Pay"
+              },
+              {
+                "textValue": "MAESTRO",
+                "displayName": "Maestro"
+              },
+              {
+                "textValue": "MANACA",
+                "displayName": "Manaca"
+              },
+              {
+                "textValue": "MASTERCARD",
+                "displayName": "MasterCard"
+              },
+              {
+                "textValue": "MIPAY",
+                "displayName": "Mi Pay"
+              },
+              {
+                "textValue": "MONIZZE",
+                "displayName": "Monizze"
+              },
+              {
+                "textValue": "MONSTERCARD",
+                "displayName": "MONST"
+              },
+              {
+                "textValue": "MPAY",
+                "displayName": "MPay"
+              },
+              {
+                "textValue": "Manuelle Lastsch",
+                "displayName": "Manuelle Lastschrift"
+              },
+              {
+                "textValue": "Merpay",
+                "displayName": "メルPay"
+              },
+              {
+                "textValue": "NANACO",
+                "displayName": "nanaco"
+              },
+              {
+                "textValue": "NEXI",
+                "displayName": "Nexi"
+              },
+              {
+                "textValue": "NIMOCA",
+                "displayName": "Nimoca"
+              },
+              {
+                "textValue": "OREM",
+                "displayName": "Onder Rembours"
+              },
+              {
+                "textValue": "PASMO",
+                "displayName": "Pasmo"
+              },
+              {
+                "textValue": "PAYBACKPAY",
+                "displayName": "Payback Pay"
+              },
+              {
+                "textValue": "PAYBOX",
+                "displayName": "Paybox"
+              },
+              {
+                "textValue": "PAYCONIQ",
+                "displayName": "Payconiq"
+              },
+              {
+                "textValue": "PAYPAL",
+                "displayName": "PayPal"
+              },
+              {
+                "textValue": "PAYPAY",
+                "displayName": "PayPay"
+              },
+              {
+                "textValue": "PAYSEC",
+                "displayName": "PaySec"
+              },
+              {
+                "textValue": "PIN",
+                "displayName": "PIN"
+              },
+              {
+                "textValue": "POSTEPAY",
+                "displayName": "Postepay"
+              },
+              {
+                "textValue": "QRCODE",
+                "displayName": "QR Code Payment"
+              },
+              {
+                "textValue": "QUICPAY",
+                "displayName": "QUICPay"
+              },
+              {
+                "textValue": "RAKUTENEDY",
+                "displayName": "Rakuten Edy"
+              },
+              {
+                "textValue": "RAKUTENPAY",
+                "displayName": "楽天Pay"
+              },
+              {
+                "textValue": "SAMSUNGPAY",
+                "displayName": "Samsung Pay"
+              },
+              {
+                "textValue": "SODEXO",
+                "displayName": "Sodexo"
+              },
+              {
+                "textValue": "SUGOCA",
+                "displayName": "Sugoca"
+              },
+              {
+                "textValue": "SUICA",
+                "displayName": "Suica"
+              },
+              {
+                "textValue": "SWISH",
+                "displayName": "Swish"
+              },
+              {
+                "textValue": "TEST",
+                "displayName": "TEST CARD"
+              },
+              {
+                "textValue": "TICKETRESTAURANT",
+                "displayName": "Ticket Restaurant"
+              },
+              {
+                "textValue": "TOICA",
+                "displayName": "Toica"
+              },
+              {
+                "textValue": "TRAVELERSCHECK",
+                "displayName": "Traveler's Check"
+              },
+              {
+                "textValue": "TSCUBIC",
+                "displayName": "TS CUBIC"
+              },
+              {
+                "textValue": "TWINT",
+                "displayName": "Twint"
+              },
+              {
+                "textValue": "UNIONPAY",
+                "displayName": "China UnionPay"
+              },
+              {
+                "textValue": "VEV",
+                "displayName": "Via een verzekering"
+              },
+              {
+                "textValue": "VISA",
+                "displayName": "Visa"
+              },
+              {
+                "textValue": "VISAELECTRON",
+                "displayName": "Visa Electron"
+              },
+              {
+                "textValue": "VOB",
+                "displayName": "Vooruit betalen"
+              },
+              {
+                "textValue": "VOUCHER",
+                "displayName": "Voucher"
+              },
+              {
+                "textValue": "VPAY",
+                "displayName": "V PAY"
+              },
+              {
+                "textValue": "WAON",
+                "displayName": "WAON"
+              },
+              {
+                "textValue": "WECHATPAY",
+                "displayName": "WeChat Pay"
+              },
+              {
+                "textValue": "WIRETRANSFER",
+                "displayName": "Wire Transfer"
+              },
+              {
+                "textValue": "YEET",
+                "displayName": "Yeeterama"
+              },
+              {
+                "textValue": "Yucho Pay",
+                "displayName": "ゆうちょPay"
+              },
+              {
+                "textValue": "ZELLE",
+                "displayName": "Zelle"
+              },
+              {
+                "textValue": "auPay",
+                "displayName": "auPay"
+              },
+              {
+                "textValue": "dBarai",
+                "displayName": "d払い "
+              },
+              {
+                "textValue": "Überweisung",
+                "displayName": "Banküberweisung"
+              }
+            ]
+          }
+        },
+        {
+          "name": "pickupCoordinate",
+          "definition": {
+            "name": "pickupCoordinate",
+            "registryId": "location.pickup_coordinate",
+            "typeRegistryId": "type.coordinate",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "latitude",
+                "definition": {
+                  "name": "latitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              },
+              {
+                "name": "longitude",
+                "definition": {
+                  "name": "longitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "priceRange",
+          "definition": {
+            "name": "priceRange",
+            "registryId": "location.price_range",
+            "typeRegistryId": "type.option",
+            "type": {
+              "stringType": "STRING_TYPE_OPTION"
+            },
+            "options": [
+              {
+                "textValue": "UNSPECIFIED",
+                "displayName": "Unspecified"
+              },
+              {
+                "textValue": "ONE",
+                "displayName": "$"
+              },
+              {
+                "textValue": "TWO",
+                "displayName": "$$"
+              },
+              {
+                "textValue": "THREE",
+                "displayName": "$$$"
+              },
+              {
+                "textValue": "FOUR",
+                "displayName": "$$$$"
+              }
+            ]
+          }
+        },
+        {
+          "name": "products",
+          "definition": {
+            "name": "products",
+            "registryId": "location.products",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_DEFAULT"
+            },
+            "isList": true
+          }
+        },
+        {
+          "name": "reservationUrl",
+          "definition": {
+            "name": "reservationUrl",
+            "registryId": "location.reservation_url",
+            "typeRegistryId": "type.url",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "url",
+                "definition": {
+                  "name": "url",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_URL"
+                  }
+                }
+              },
+              {
+                "name": "displayUrl",
+                "definition": {
+                  "name": "displayUrl",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_URL"
+                  }
+                }
+              },
+              {
+                "name": "preferDisplayUrl",
+                "definition": {
+                  "name": "preferDisplayUrl",
+                  "typeRegistryId": "type.boolean",
+                  "type": {
+                    "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "routableCoordinate",
+          "definition": {
+            "name": "routableCoordinate",
+            "registryId": "location.routable_coordinate",
+            "typeRegistryId": "type.coordinate",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "latitude",
+                "definition": {
+                  "name": "latitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              },
+              {
+                "name": "longitude",
+                "definition": {
+                  "name": "longitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "services",
+          "definition": {
+            "name": "services",
+            "registryId": "location.services",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_DEFAULT"
+            },
+            "isList": true
+          }
+        },
+        {
+          "name": "specialities",
+          "definition": {
+            "name": "specialities",
+            "registryId": "location.specialties",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_DEFAULT"
+            },
+            "isList": true
+          }
+        },
+        {
+          "name": "timezone",
+          "definition": {
+            "name": "timezone",
+            "registryId": "location.time_zone",
+            "typeRegistryId": "type.time_zone",
+            "type": {
+              "stringType": "STRING_TYPE_TIME_ZONE"
+            }
+          }
+        },
+        {
+          "name": "tollFreePhone",
+          "definition": {
+            "name": "tollFreePhone",
+            "registryId": "location.toll_free",
+            "typeRegistryId": "type.phone",
+            "type": {
+              "stringType": "STRING_TYPE_PHONE"
+            }
+          }
+        },
+        {
+          "name": "ttyPhone",
+          "definition": {
+            "name": "ttyPhone",
+            "registryId": "location.tty_phone",
+            "typeRegistryId": "type.phone",
+            "type": {
+              "stringType": "STRING_TYPE_PHONE"
+            }
+          }
+        },
+        {
+          "name": "twitterHandle",
+          "definition": {
+            "name": "twitterHandle",
+            "registryId": "location.twitter_handle",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_DEFAULT"
+            }
+          }
+        },
+        {
+          "name": "walkableCoordinate",
+          "definition": {
+            "name": "walkableCoordinate",
+            "registryId": "location.walkable_coordinate",
+            "typeRegistryId": "type.coordinate",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "latitude",
+                "definition": {
+                  "name": "latitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              },
+              {
+                "name": "longitude",
+                "definition": {
+                  "name": "longitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "websiteUrl",
+          "definition": {
+            "name": "websiteUrl",
+            "registryId": "location.website",
+            "typeRegistryId": "type.url",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "url",
+                "definition": {
+                  "name": "url",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_URL"
+                  }
+                }
+              },
+              {
+                "name": "displayUrl",
+                "definition": {
+                  "name": "displayUrl",
+                  "typeRegistryId": "type.string",
+                  "type": {
+                    "stringType": "STRING_TYPE_URL"
+                  }
+                }
+              },
+              {
+                "name": "preferDisplayUrl",
+                "definition": {
+                  "name": "preferDisplayUrl",
+                  "typeRegistryId": "type.boolean",
+                  "type": {
+                    "booleanType": "BOOLEAN_TYPE_DEFAULT"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "yearEstablished",
+          "definition": {
+            "name": "yearEstablished",
+            "registryId": "location.year_established",
+            "typeRegistryId": "type.integer",
+            "type": {
+              "numberType": "NUMBER_TYPE_INT"
+            }
+          }
+        },
+        {
+          "name": "yextDisplayCoordinate",
+          "definition": {
+            "name": "yextDisplayCoordinate",
+            "registryId": "location.yext_display_coordinate",
+            "typeRegistryId": "type.coordinate",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "latitude",
+                "definition": {
+                  "name": "latitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              },
+              {
+                "name": "longitude",
+                "definition": {
+                  "name": "longitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "yextDropoffCoordinate",
+          "definition": {
+            "name": "yextDropoffCoordinate",
+            "registryId": "location.yext_dropoff_coordinate",
+            "typeRegistryId": "type.coordinate",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "latitude",
+                "definition": {
+                  "name": "latitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              },
+              {
+                "name": "longitude",
+                "definition": {
+                  "name": "longitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "yextPickupCoordinate",
+          "definition": {
+            "name": "yextPickupCoordinate",
+            "registryId": "location.yext_pickup_coordinate",
+            "typeRegistryId": "type.coordinate",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "latitude",
+                "definition": {
+                  "name": "latitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              },
+              {
+                "name": "longitude",
+                "definition": {
+                  "name": "longitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "yextRoutableCoordinate",
+          "definition": {
+            "name": "yextRoutableCoordinate",
+            "registryId": "location.yext_routable_coordinate",
+            "typeRegistryId": "type.coordinate",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "latitude",
+                "definition": {
+                  "name": "latitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              },
+              {
+                "name": "longitude",
+                "definition": {
+                  "name": "longitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "yextWalkableCoordinate",
+          "definition": {
+            "name": "yextWalkableCoordinate",
+            "registryId": "location.yext_walkable_coordinate",
+            "typeRegistryId": "type.coordinate",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "latitude",
+                "definition": {
+                  "name": "latitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              },
+              {
+                "name": "longitude",
+                "definition": {
+                  "name": "longitude",
+                  "typeRegistryId": "type.float",
+                  "type": {
+                    "numberType": "NUMBER_TYPE_FLOAT"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "videos",
+          "definition": {
+            "name": "videos",
+            "registryId": "location.youtube_videos",
+            "typeRegistryId": "type.video",
+            "type": {
+              "objectType": "OBJECT_TYPE_COMPLEX_VIDEO"
+            },
+            "isList": true
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "video",
+                "definition": {
+                  "name": "video",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_VIDEO"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "url",
+                      "definition": {
+                        "name": "url",
+                        "type": {
+                          "stringType": "STRING_TYPE_URL"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "description",
+                "definition": {
+                  "name": "description",
+                  "type": {
+                    "stringType": "STRING_TYPE_MULTILINE"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "meta",
+          "definition": {
+            "name": "meta",
+            "type": {
+              "objectType": "OBJECT_TYPE_DEFAULT"
+            }
+          },
+          "children": {
+            "fields": [
+              {
+                "name": "locale",
+                "definition": {
+                  "name": "locale",
+                  "type": {
+                    "stringType": "STRING_TYPE_DEFAULT"
+                  }
+                }
+              },
+              {
+                "name": "entityType",
+                "definition": {
+                  "name": "entityType",
+                  "type": {
+                    "objectType": "OBJECT_TYPE_DEFAULT"
+                  }
+                },
+                "children": {
+                  "fields": [
+                    {
+                      "name": "uid",
+                      "definition": {
+                        "name": "uid",
+                        "type": {
+                          "numberType": "NUMBER_TYPE_ID"
+                        }
+                      }
+                    },
+                    {
+                      "name": "id",
+                      "definition": {
+                        "name": "id",
+                        "type": {
+                          "stringType": "STRING_TYPE_ID"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "id",
+          "definition": {
+            "name": "id",
+            "registryId": "location.store_id",
+            "typeRegistryId": "type.string",
+            "type": {
+              "stringType": "STRING_TYPE_ID"
+            }
+          }
+        },
+        {
+          "name": "uid",
+          "definition": {
+            "name": "uid",
+            "type": {
+              "numberType": "NUMBER_TYPE_ID"
+            }
+          }
+        }
+      ]
+    },
+    "createTime": "2025-01-14T19:48:49Z",
+    "updateTime": "2025-01-14T19:48:49Z"
+  }
+};

--- a/src/templates/dev.tsx
+++ b/src/templates/dev.tsx
@@ -1,0 +1,129 @@
+import "@yext/visual-editor/style.css";
+import {
+  Template,
+  TemplateConfig,
+  GetPath,
+  TemplateProps,
+  TemplateRenderProps,
+  GetHeadConfig,
+  HeadConfig,
+} from "@yext/pages";
+import {componentRegistry} from "../ve.config";
+import {
+  applyTheme, Editor,
+  VisualEditorProvider,
+  YextSchemaField,
+} from "@yext/visual-editor";
+import { themeConfig } from "../../theme.config";
+import { buildSchema } from "../utils/buildSchema";
+import tailwindConfig from "../../tailwind.config";
+import { devTemplateStream } from "../dev.config";
+
+export const config = {
+  name: "dev-location",
+  stream: {
+    $id: "dev-location-stream",
+    filter: {
+      entityTypes: ["location"],
+    },
+    fields: [
+      "id",
+      "uid",
+      "meta",
+      "slug",
+      "name",
+      "hours",
+      "dineInHours",
+      "driveThroughHours",
+      "address",
+      "yextDisplayCoordinate",
+      "c_productSection.sectionTitle",
+      "c_productSection.linkedProducts.name",
+      "c_productSection.linkedProducts.c_productPromo",
+      "c_productSection.linkedProducts.c_description",
+      "c_productSection.linkedProducts.c_coverPhoto",
+      "c_productSection.linkedProducts.c_productCTA",
+      "c_hero",
+      "c_faqSection.linkedFAQs.question",
+      "c_faqSection.linkedFAQs.answerV2",
+      "additionalHoursText",
+      "mainPhone",
+      "emails",
+      "services",
+      "c_deliveryPromo",
+    ],
+    localization: {
+      locales: ["en"],
+    },
+  },
+  additionalProperties: {
+    isVETemplate: true,
+  },
+} as const satisfies TemplateConfig;
+export const transformProps = async (data: any) => {
+  const emptyLayout = {
+    root: {},
+    content: [],
+    zones: {},
+  };
+  const updatedDocument = data;
+  if (!updatedDocument.document.__) {
+    updatedDocument.document.__ = {};
+  }
+  updatedDocument.document.__.layout = emptyLayout;
+
+  return updatedDocument;
+};
+
+export const getHeadConfig: GetHeadConfig<TemplateRenderProps> = ({
+  document,
+}): HeadConfig => {
+  return {
+    title: document.name,
+    charset: "UTF-8",
+    viewport: "width=device-width, initial-scale=1",
+    tags: [
+      {
+        type: "link",
+        attributes: {
+          rel: "icon",
+          type: "image/x-icon",
+        },
+      },
+    ],
+    other: [applyTheme(document, themeConfig), buildSchema(document)].join(
+      "\n"
+    ),
+  };
+};
+
+export const getPath: GetPath<TemplateProps> = ({ document }) => {
+  const localePath = document.locale !== "en" ? `${document.locale}/` : "";
+  return "dev/" + document.address
+      ? `${localePath}${document.address.region}/${document.address.city}/${
+          document.address.line1
+      }-${document.id.toString()}`
+      : `${localePath}${document.id.toString()}`;
+};
+
+const Dev: Template<TemplateRenderProps> = (props) => {
+  const { document } = props;
+  const entityFields = devTemplateStream.stream.schema.fields as unknown as YextSchemaField[];
+
+  return (
+      <VisualEditorProvider
+          document={document}
+          entityFields={entityFields}
+          tailwindConfig={tailwindConfig}
+      >
+        <Editor
+            document={document}
+            componentRegistry={componentRegistry}
+            themeConfig={themeConfig}
+            localDev={true}
+        />
+      </VisualEditorProvider>
+  );
+};
+
+export default Dev;

--- a/src/ve.config.tsx
+++ b/src/ve.config.tsx
@@ -88,4 +88,5 @@ export const mainConfig: Config<MainProps> = {
 
 export const componentRegistry = new Map<string, Config<any>>([
   ["main", mainConfig],
+  ["dev", mainConfig]
 ]);


### PR DESCRIPTION
Adds a new "dev" template which can be used to test components locally.

Package.json is linked to a version of VE that includes support for localDev mode.
 https://github.com/yext/visual-editor/pull/194

To use, run "npm run dev -- --local --no-prod-url"

Then open any of the dev/ pages and you will be shown an empty puck editor.

You can now add components and use entity data.

The publish button is hidden and Clear Local Changes will reset the local editor to a blank/default state.

dev.config.ts includes the entity fields returned from templateStream.

The provided data should work for most situations. To update it to match a site, just copy/paste the return value of /templateStream request in platform.