### PR TITLE
feat: use YEXT_PUBLIC_EVENTS_API_KEY from the document

### DIFF
--- a/src/templates/main.tsx
+++ b/src/templates/main.tsx
@@ -75,8 +75,7 @@ const Location: Template<TemplateRenderProps> = (props) => {
 
   return (
     <AnalyticsProvider
-      // @ts-expect-error ts(2304) the api key will be populated
-      apiKey={YEXT_PUBLIC_EVENTS_API_KEY}
+      apiKey={document?._env?.YEXT_PUBLIC_EVENTS_API_KEY}
       templateData={props}
       currency="USD"
     >


### PR DESCRIPTION
Added console logs to verify that the key exists and was being passed to the AnalyticsProvider