### PR TITLE
fix: guard meta description

### DIFF
--- a/src/templates/main.tsx
+++ b/src/templates/main.tsx
@@ -39,13 +39,17 @@ export const getHeadConfig: GetHeadConfig<TemplateRenderProps> = ({
           type: "image/x-icon",
         },
       },
-      {
-        type: "meta",
-        attributes: {
-          name: "description",
-          content: description ?? "",
-        },
-      },
+      ...(description
+          ? [
+            {
+              type: "meta" as TagType,
+              attributes: {
+                name: "description",
+                content: description,
+              },
+            },
+          ]
+          : []),
       ...(faviconUrl
         ? [
             {

--- a/src/templates/main.tsx
+++ b/src/templates/main.tsx
@@ -43,7 +43,7 @@ export const getHeadConfig: GetHeadConfig<TemplateRenderProps> = ({
         type: "meta",
         attributes: {
           name: "description",
-          content: description,
+          content: description ?? "",
         },
       },
       ...(faviconUrl


### PR DESCRIPTION
Does not include the description tag if there is no description