### PR TITLE
chore: update pages 1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@typescript-eslint/eslint-plugin": "^6.16.0",
         "@typescript-eslint/parser": "^6.16.0",
         "@vitejs/plugin-react": "^4.2.1",
-        "@yext/pages": "1.2.0-beta.4",
+        "@yext/pages": "1.2.1",
         "@yext/pages-components": "^1.1.4",
         "@yext/visual-editor": "0.0.33",
         "autoprefixer": "^10.4.8",
@@ -4241,11 +4241,10 @@
       }
     },
     "node_modules/@yext/pages": {
-      "version": "1.2.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@yext/pages/-/pages-1.2.0-beta.4.tgz",
-      "integrity": "sha512-P/6rhb0T7corEd3nk6Wr+eyEZTMUqCAGLRLERy5e1PLN9kFhAM7OySUfDoQKKf9Sij/mrx4HcxMP4Pi0MKDyRQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@yext/pages/-/pages-1.2.1.tgz",
+      "integrity": "sha512-5Ot5c4W6FWS/xy6ZfMld6RrzlH2fTScilU08frGjjWntzSZLITk4slFJFxxsn1/p7ZYM2iqQ1fjaIUHprLAkvg==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "ansi-to-html": "^0.7.2",
         "browser-or-node": "^2.1.1",
@@ -4278,7 +4277,7 @@
         "pages": "dist/bin/spawn.js"
       },
       "engines": {
-        "node": "^18 || ^20.2.0"
+        "node": "^18 || ^20.2.0 || ^22"
       },
       "peerDependencies": {
         "react": "^17.0.2 || ^18.2.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@typescript-eslint/eslint-plugin": "^6.16.0",
     "@typescript-eslint/parser": "^6.16.0",
     "@vitejs/plugin-react": "^4.2.1",
-    "@yext/pages": "1.2.0-beta.4",
+    "@yext/pages": "1.2.1",
     "@yext/pages-components": "^1.1.4",
     "@yext/visual-editor": "0.0.33",
     "autoprefixer": "^10.4.8",

--- a/src/templates/directory.tsx
+++ b/src/templates/directory.tsx
@@ -72,11 +72,6 @@ export const getHeadConfig: GetHeadConfig<TemplateRenderProps> = ({
 };
 
 export const getPath: GetPath<TemplateProps> = ({ document }) => {
-  if (!document?.__?.layout) {
-    // temporary: guard for generated repo-based static page
-    return `static-${Math.floor(Math.random() * (10000 - 1))}`;
-  }
-  
   if (document.slug) {
     return document.slug;
   }
@@ -90,11 +85,6 @@ export const getPath: GetPath<TemplateProps> = ({ document }) => {
 const Directory: Template<TemplateRenderProps> = (props) => {
   const { document } = props;
 
-  // temporary: guard for generated repo-based static page
-  if (!document?.__?.layout) {
-    return <></>;
-  }
-
   return (
     <AnalyticsProvider
       apiKey={document?._env?.YEXT_PUBLIC_EVENTS_API_KEY}
@@ -102,7 +92,10 @@ const Directory: Template<TemplateRenderProps> = (props) => {
       currency="USD"
     >
       <VisualEditorProvider templateProps={props}>
-        <Render config={directoryConfig} data={JSON.parse(document.__.layout)} />
+        <Render
+          config={directoryConfig}
+          data={JSON.parse(document.__.layout)}
+        />
       </VisualEditorProvider>
     </AnalyticsProvider>
   );

--- a/src/templates/main.tsx
+++ b/src/templates/main.tsx
@@ -72,11 +72,6 @@ export const getHeadConfig: GetHeadConfig<TemplateRenderProps> = ({
 };
 
 export const getPath: GetPath<TemplateProps> = ({ document }) => {
-  if (!document?.__?.layout) {
-    // temporary: guard for generated repo-based static page
-    return `static-${Math.floor(Math.random() * (10000 - 1))}`;
-  }
-
   if (document.slug) {
     return document.slug;
   }
@@ -91,11 +86,6 @@ export const getPath: GetPath<TemplateProps> = ({ document }) => {
 
 const Main: Template<TemplateRenderProps> = (props) => {
   const { document } = props;
-
-  // temporary: guard for generated repo-based static page
-  if (!document?.__?.layout) {
-    return <></>;
-  }
 
   return (
     <AnalyticsProvider


### PR DESCRIPTION
- includes dev mode changes
- includes fix for static page generation so we no longer need the guards (tested & it succeeds this time)

Run `npm run dev -- --siteId x` to use in-platform dev mode 