### PR TITLE
feat: add theme editor to local-editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "@vitejs/plugin-react": "^4.2.1",
         "@yext/pages": "https://raw.githubusercontent.com/jwartofsky-yext/publicAssets/main/packs/pages_3_20_26.tgz",
         "@yext/pages-components": "2.1.0",
-        "@yext/visual-editor": "https://raw.githubusercontent.com/jwartofsky-yext/publicAssets/main/packs/yext-visual-editor-1.2.2-brand-styles.tgz",
+        "@yext/visual-editor": "https://raw.githubusercontent.com/jwartofsky-yext/publicAssets/main/packs/yext-visual-editor-1.2.2-local-theme-editor.tgz",
         "autoprefixer": "^10.4.8",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-react": "^7.31.7",
@@ -5319,8 +5319,8 @@
     },
     "node_modules/@yext/visual-editor": {
       "version": "1.2.2",
-      "resolved": "https://raw.githubusercontent.com/jwartofsky-yext/publicAssets/main/packs/yext-visual-editor-1.2.2-brand-styles.tgz",
-      "integrity": "sha512-SCPElzlLLiZ72NGJ7Cah8bd2Y1X3gM3ZVHvuqQLVM/R8iaEHhivuwr6FfbSvExwGCZgQQ1Vlvi+I9nHuRY9rXQ==",
+      "resolved": "https://raw.githubusercontent.com/jwartofsky-yext/publicAssets/main/packs/yext-visual-editor-1.2.2-local-theme-editor.tgz",
+      "integrity": "sha512-EOsOQOc95cwYRaL4rNKIdVGd5K5OXgtk9yJS0kCODFduCOMac41oIqBFVH/GxMz3K/6G9lwRpJgo9rAPPiuChA==",
       "dev": true,
       "dependencies": {
         "@mapbox/maki": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "@yext/pages": "https://raw.githubusercontent.com/jwartofsky-yext/publicAssets/main/packs/pages_3_20_26.tgz",
     "@yext/pages-components": "2.1.0",
-    "@yext/visual-editor": "https://raw.githubusercontent.com/jwartofsky-yext/publicAssets/main/packs/yext-visual-editor-1.2.2-brand-styles.tgz",
+    "@yext/visual-editor": "https://raw.githubusercontent.com/jwartofsky-yext/publicAssets/main/packs/yext-visual-editor-1.2.2-local-theme-editor.tgz",
     "autoprefixer": "^10.4.8",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-react": "^7.31.7",


### PR DESCRIPTION
This upgrades the visual-editor pack to one that includes the ability to access the theme editor and customize themes in the local-editor.