### PR TITLE
chore: update visual-editor pack to include 1.3.1 changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "@vitejs/plugin-react": "^4.2.1",
         "@yext/pages": "https://raw.githubusercontent.com/jwartofsky-yext/publicAssets/main/packs/pages_3_20_26.tgz",
         "@yext/pages-components": "2.1.0",
-        "@yext/visual-editor": "https://raw.githubusercontent.com/jwartofsky-yext/publicAssets/main/packs/yext-visual-editor-1.2.2-local-theme-editor.tgz",
+        "@yext/visual-editor": "https://raw.githubusercontent.com/jwartofsky-yext/publicAssets/main/packs/yext-visual-editor-1.3.1.tgz",
         "autoprefixer": "^10.4.8",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-react": "^7.31.7",
@@ -5318,9 +5318,9 @@
       }
     },
     "node_modules/@yext/visual-editor": {
-      "version": "1.2.2",
-      "resolved": "https://raw.githubusercontent.com/jwartofsky-yext/publicAssets/main/packs/yext-visual-editor-1.2.2-local-theme-editor.tgz",
-      "integrity": "sha512-EOsOQOc95cwYRaL4rNKIdVGd5K5OXgtk9yJS0kCODFduCOMac41oIqBFVH/GxMz3K/6G9lwRpJgo9rAPPiuChA==",
+      "version": "1.3.1",
+      "resolved": "https://raw.githubusercontent.com/jwartofsky-yext/publicAssets/main/packs/yext-visual-editor-1.3.1.tgz",
+      "integrity": "sha512-5vLeRkiEubTITPhwlojltkEuQhhARX9GzxjE9nJJ+I26bWw0TG7lpV5/f7EsvWhUiwEov5jVk67Vpyr+viMIpw==",
       "dev": true,
       "dependencies": {
         "@mapbox/maki": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "@yext/pages": "https://raw.githubusercontent.com/jwartofsky-yext/publicAssets/main/packs/pages_3_20_26.tgz",
     "@yext/pages-components": "2.1.0",
-    "@yext/visual-editor": "https://raw.githubusercontent.com/jwartofsky-yext/publicAssets/main/packs/yext-visual-editor-1.2.2-local-theme-editor.tgz",
+    "@yext/visual-editor": "https://raw.githubusercontent.com/jwartofsky-yext/publicAssets/main/packs/yext-visual-editor-1.3.1.tgz",
     "autoprefixer": "^10.4.8",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-react": "^7.31.7",


### PR DESCRIPTION
Includes changes from 1.3.1, as well as the theme editor in local-editor.