### PR TITLE
chore: add reverse-proxy-prefix to build

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 buildConfiguration:
-  buildCommand: npm run build
+  buildCommand: npm run build -- --reverse-proxy-prefix=$YEXT_REVERSE_PROXY_PREFIX
   installDependenciesStep:
     command: npm install
     requiredFiles:


### PR DESCRIPTION
Adds " -- --reverse-proxy-prefix=$YEXT_REVERSE_PROXY_PREFIX" to the build cmd in config.yaml

Tested here: https://dev.yext.com/s/1000168938/yextsites/67425/branch/7079/deploys/recent

Note that if we include environment variable `YEXT_REVERSE_PROXY_PREFIX`, site settings will show that the URL redirects are defined in the repository
<img width="712" height="206" alt="image" src="https://github.com/user-attachments/assets/841ca38f-9308-44cd-b76d-7bc9d24637d4" />

If the environment variable is not included, the option is available like normal.

You can see what the results of running with the prefix look like in the repo here: https://github.com/YextSolutions/pages-visual-editor-starter/pull/330/changes#diff-d8d0422389f03d783e32e627250fe29834bd09c6361640d1ff00661dd6820034