### PR TITLE
fix: only pass reverse proxy prefix if env var is present

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 buildConfiguration:
-  buildCommand: npm run build -- --reverse-proxy-prefix=$YEXT_REVERSE_PROXY_PREFIX
+  buildCommand: npm run build -- ${YEXT_REVERSE_PROXY_PREFIX:+--reverse-proxy-prefix="$YEXT_REVERSE_PROXY_PREFIX"}
   installDependenciesStep:
     command: npm install
     requiredFiles:


### PR DESCRIPTION
Previously, we unconditionally passed the `reverse_proxy_prefix` argument, even if the environment variable wasn't present. This would pass an empty string to the build context, which would fail validation. Update to only set the build argument if the environment variable is present.

TEST=manual

Ran `yext pages build` with and without change. Without change, saw empty string fail validation. With change, saw build run successfully.