### PR TITLE
fix: increase bundle limit

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 buildConfiguration:
-  buildCommand: npm run build -- ${YEXT_REVERSE_PROXY_PREFIX:+--reverse-proxy-prefix="$YEXT_REVERSE_PROXY_PREFIX"}
+  buildCommand: npm run build -- ${YEXT_REVERSE_PROXY_PREFIX:+--reverse-proxy-prefix="$YEXT_REVERSE_PROXY_PREFIX"} --pluginTotalFilesizeLimit 15
   installDependenciesStep:
     command: npm install
     requiredFiles:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "pages dev",
     "prod": "pages prod",
-    "build": "pages build",
+    "build": "pages build -- --pluginTotalFilesizeLimit 15",
     "typecheck": "tsc --noEmit",
     "generate:template-configs": "node --import tsx scripts/generateTemplateConfig.ts"
   },


### PR DESCRIPTION
The default bundle limit is 10 MB but that's been failing some artifact generations

https://yext.slack.com/archives/C0BCPLHJPGC/p1785777541614149