### PR TITLE
chore: upgrade yext/visual-editor to 1.4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@vitejs/plugin-react": "^4.2.1",
         "@yext/pages": "1.3.2",
         "@yext/pages-components": "2.2.0",
-        "@yext/visual-editor": "1.4.4",
+        "@yext/visual-editor": "1.4.5",
         "autoprefixer": "^10.4.8",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-react": "^7.31.7",
@@ -4683,9 +4683,9 @@
       }
     },
     "node_modules/@yext/visual-editor": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@yext/visual-editor/-/visual-editor-1.4.4.tgz",
-      "integrity": "sha512-jSEWQAUig1asRUuLaxgs/pwJiRdvoEGYRap98QJYPLvg/kS6WykjRRNu5zo9oazifSIEPSB2uoUVEZ6GqnO+VA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@yext/visual-editor/-/visual-editor-1.4.5.tgz",
+      "integrity": "sha512-NL54/RfpkZyZwCwVdLsa2adSe3rziwY+zKkXWHhREUHifekODoB98clTAEbTFe2uBDoiDs0NE2nqTFMB8b2e/g==",
       "dev": true,
       "dependencies": {
         "@mapbox/maki": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "@yext/pages": "1.3.2",
     "@yext/pages-components": "2.2.0",
-    "@yext/visual-editor": "1.4.4",
+    "@yext/visual-editor": "1.4.5",
     "autoprefixer": "^10.4.8",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-react": "^7.31.7",


### PR DESCRIPTION
#### 1.4.5 (2026-08-13)

##### Chores

- update js-yaml version ([#1286](https://github.com/yext/visual-editor/pull/1286)) ([46c322fd](https://github.com/yext/visual-editor/commit/46c322fd11ec5fef319d4bf63a75be1556e4adfa))

##### Bug Fixes

- preserve directory card data ([#1284](https://github.com/yext/visual-editor/pull/1284)) ([7f3bd989](https://github.com/yext/visual-editor/commit/7f3bd989d8e735265c2066c761b1e7a8319c66cf))
